### PR TITLE
catch errors caused by premuaturely aborted streams on the deserialization side

### DIFF
--- a/packages/plugins/web/readable-stream.ts
+++ b/packages/plugins/web/readable-stream.ts
@@ -29,11 +29,11 @@ const ReadableStreamFactoryPlugin = /* @__PURE__ */ createPlugin<
         ctx.createEffectfulFunction(
           ['c'],
           'd.on({next:' +
-            ctx.createEffectfulFunction(['v'], 'c.enqueue(v)') +
+            ctx.createEffectfulFunction(['v'], 'try{c.enqueue(v)}catch{}') +
             ',throw:' +
             ctx.createEffectfulFunction(['v'], 'c.error(v)') +
             ',return:' +
-            ctx.createEffectfulFunction([], 'c.close()') +
+            ctx.createEffectfulFunction([], 'try{c.close()}catch{}') +
             '})',
         ) +
         '})',
@@ -122,13 +122,17 @@ const ReadableStreamPlugin = /* @__PURE__ */ createPlugin<
       start(controller): void {
         stream.on({
           next(value) {
-            controller.enqueue(value);
+            try {
+              controller.enqueue(value);
+            } catch {}
           },
           throw(value) {
             controller.error(value);
           },
           return() {
-            controller.close();
+            try {
+              controller.close();
+            } catch {}
           },
         });
       },


### PR DESCRIPTION
This is something I've encountered while working on the [Apollo Client integration for TanStack Start](https://github.com/apollographql/apollo-client-integrations/pull/501).

If for whatever reason the consuming side decides that they are no longer interested in incoming values and close a streamed-in stream via `reader.cancel()`, that will close the stream, but of course it won't prevent values and the final `close` command from streaming in.

That will then result in errors like `Cannot close a stream that is already closed.`.

I would suggest to just ignore errors caused by writing chunks on the stream or closing it - I honestly can't think of a better option of handling this apart from adding real `closed` tracking, which probably would be way too much bundle size.