### PR TITLE
fix: make sure `depthLimit` is passed down from config

### DIFF
--- a/packages/seroval/src/core/cross/index.ts
+++ b/packages/seroval/src/core/cross/index.ts
@@ -161,6 +161,7 @@ export function toCrossJSONStream<T>(
     plugins,
     refs: options.refs,
     disabledFeatures: options.disabledFeatures,
+    depthLimit: options.depthLimit,
     onParse: options.onParse,
     onError: options.onError,
     onDone: options.onDone,
@@ -183,6 +184,7 @@ export function fromCrossJSON<T>(
     refs: options.refs,
     features: options.features,
     disabledFeatures: options.disabledFeatures,
+    depthLimit: options.depthLimit,
   });
   return deserializeTop(ctx, source) as T;
 }

--- a/packages/seroval/test/async-iterable.test.ts
+++ b/packages/seroval/test/async-iterable.test.ts
@@ -21,6 +21,16 @@ const EXAMPLE = {
   },
 };
 
+function makeDeepObject(depth: number): Record<string, unknown> {
+  let current: Record<string, unknown> = {};
+  const root = current;
+  for (let i = 0; i < depth; i++) {
+    current.next = {};
+    current = current.next as Record<string, unknown>;
+  }
+  return root;
+}
+
 describe('AsyncIterable', () => {
   describe('serializeAsync', () => {
     it('supports AsyncIterables', async () => {
@@ -122,6 +132,23 @@ describe('AsyncIterable', () => {
           },
           onError(error) {
             reject(error);
+          },
+        });
+      }));
+    it('respects depthLimit', async () =>
+      new Promise<void>(resolve => {
+        const deep = makeDeepObject(5);
+        let parsed = false;
+        toCrossJSONStream(deep, {
+          depthLimit: 2,
+          onParse() {
+            parsed = true;
+          },
+          onError(error) {
+            expect(error).toBeInstanceOf(Error);
+            expect((error as Error).message).toContain('Depth limit');
+            expect(parsed).toBe(false);
+            resolve();
           },
         });
       }));

--- a/packages/seroval/test/iterable.test.ts
+++ b/packages/seroval/test/iterable.test.ts
@@ -24,6 +24,16 @@ const EXAMPLE = {
   },
 };
 
+function makeDeepObject(depth: number): Record<string, unknown> {
+  let current: Record<string, unknown> = {};
+  const root = current;
+  for (let i = 0; i < depth; i++) {
+    current.next = {};
+    current = current.next as Record<string, unknown>;
+  }
+  return root;
+}
+
 describe('Iterable', () => {
   describe('serialize', () => {
     it('supports Iterables', () => {
@@ -181,5 +191,34 @@ describe('Iterable', () => {
           },
         });
       }));
+    it('respects depthLimit', async () =>
+      new Promise<void>(resolve => {
+        const deep = makeDeepObject(5);
+        let parsed = false;
+        toCrossJSONStream(deep, {
+          depthLimit: 2,
+          onParse() {
+            parsed = true;
+          },
+          onError(error) {
+            expect(error).toBeInstanceOf(Error);
+            expect((error as Error).message).toContain('Depth limit');
+            expect(parsed).toBe(false);
+            resolve();
+          },
+        });
+      }));
+  });
+  describe('fromCrossJSON', () => {
+    it('respects depthLimit', () => {
+      const deep = makeDeepObject(5);
+      const tree = toCrossJSON(deep);
+      expect(() =>
+        fromCrossJSON(tree, {
+          depthLimit: 2,
+          refs: new Map(),
+        }),
+      ).toThrowError(/Depth limit/);
+    });
   });
 });


### PR DESCRIPTION
I noticed in SolidStart the depth limit is not being respected.
This is because the options aren't passed down to both `toCrossJSONStream` and `createCrossDeserializerContext`  methods.

Also added some tests to ensure the config is passing through consistently.
