### PR TITLE
fix: serialize plain objects that have an own `constructor` property

### DIFF
--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -473,7 +473,15 @@ export async function parseObjectAsync(
   if (isSequence(current)) {
     return parseSequence(ctx, depth, id, current);
   }
-  const currentClass = current.constructor;
+  let currentClass: unknown = current.constructor;
+  // `constructor` is an ordinary own property, so data can shadow it
+  // (`JSON.parse('{"constructor":1}')`) and hide the real class. A class is
+  // always callable, so anything else means the lookup was shadowed — only
+  // then fall back to the prototype, keeping the common path free of it.
+  if (currentClass !== NIL && typeof currentClass !== 'function') {
+    const proto = Object.getPrototypeOf(current) as object | null;
+    currentClass = proto === null ? NIL : proto.constructor;
+  }
   if (currentClass === OpaqueReference) {
     return parseAsync(
       ctx,

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -820,7 +820,15 @@ function parseObject(
   if (isSequence(current)) {
     return parseSequence(ctx, depth, id, current);
   }
-  const currentClass = current.constructor;
+  let currentClass: unknown = current.constructor;
+  // `constructor` is an ordinary own property, so data can shadow it
+  // (`JSON.parse('{"constructor":1}')`) and hide the real class. A class is
+  // always callable, so anything else means the lookup was shadowed — only
+  // then fall back to the prototype, keeping the common path free of it.
+  if (currentClass !== NIL && typeof currentClass !== 'function') {
+    const proto = Object.getPrototypeOf(current) as object | null;
+    currentClass = proto === null ? NIL : proto.constructor;
+  }
   if (currentClass === OpaqueReference) {
     return parseSOS(
       ctx,

--- a/packages/seroval/test/object.test.ts
+++ b/packages/seroval/test/object.test.ts
@@ -613,4 +613,40 @@ describe('objects', () => {
       );
     });
   });
+  describe('with a shadowed constructor property', () => {
+    const SHADOWED = { constructor: 'not a constructor', value: 42 };
+
+    it('supports serialize', () => {
+      const result = serialize(SHADOWED);
+      const back = deserialize<typeof SHADOWED>(result);
+      expect(back.constructor).toBe('not a constructor');
+      expect(back.value).toBe(42);
+    });
+    it('supports serializeAsync', async () => {
+      const result = await serializeAsync(SHADOWED);
+      const back = deserialize<typeof SHADOWED>(result);
+      expect(back.constructor).toBe('not a constructor');
+      expect(back.value).toBe(42);
+    });
+    it('supports toJSON', () => {
+      const result = toJSON(SHADOWED);
+      const back = fromJSON<typeof SHADOWED>(result);
+      expect(back.constructor).toBe('not a constructor');
+      expect(back.value).toBe(42);
+    });
+    it('keeps a null-prototype object null-prototype', () => {
+      const shadowed = Object.create(null) as Record<string, unknown>;
+      shadowed.constructor = 1;
+      const back = deserialize<Record<string, unknown>>(serialize(shadowed));
+      expect(Object.getPrototypeOf(back)).toBe(null);
+      expect(back.constructor).toBe(1);
+    });
+    it('keeps a shadowed Map a Map', () => {
+      const shadowed = new Map([['a', 1]]);
+      (shadowed as unknown as Record<string, unknown>).constructor = 1;
+      const back = deserialize<Map<string, number>>(serialize(shadowed));
+      expect(back).toBeInstanceOf(Map);
+      expect(back.get('a')).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Serializing a plain object that has an own `constructor` property throws, even though the object is otherwise an ordinary record:

```js
import { serialize } from 'seroval';

serialize({ constructor: 1 });
// SerovalParserError: Seroval caught an error during the parsing process.
//   cause: the value cannot be parsed/serialized
```

Such objects are common in practice — `JSON.parse('{"constructor": 1}')`, form payloads, API responses, anything where `constructor` is just a data key.

### Root cause

The object parser determines the value's class from `current.constructor`:

```ts
const currentClass = current.constructor;
// …
switch (currentClass) {
  case Object: return parsePlainObject(/* … */);
  case NIL:    /* null-proto */
  case Date:   /* … */
  // …
}
```

An own enumerable `constructor` property shadows the one inherited from the prototype, so for `{ constructor: 1 }` the lookup yields `1`, the switch falls through every case, and the parser ends at `throw new SerovalUnsupportedTypeError(current)`.

This affects every entry point that goes through the sync or async object parser — `serialize`, `serializeAsync`, `toJSON`, `toJSONAsync`, `toCrossJSON`, `crossSerialize`.

Shadowing also mis-parses **non-plain** values silently rather than throwing: a `Map` with an own `constructor` falls through to the iterator branch of the slow path and is emitted as a null-prototype plain object, so it stops round-tripping as a `Map`. A null-prototype object with an own `constructor` is likewise rejected.

### Fix

A class is always callable, so a non-callable `constructor` is itself the signal that the own-property lookup was shadowed. Keep the fast-path `current.constructor` read exactly as-is, and fall back to the prototype **only** when the lookup returns a non-callable value:

```ts
let currentClass: unknown = current.constructor;
if (currentClass !== NIL && typeof currentClass !== 'function') {
  const proto = Object.getPrototypeOf(current);
  currentClass = proto === null ? NIL : proto.constructor;
}
```

Every value that parses today has a callable `constructor` — built-ins, class instances, plain and null-prototype objects — so it takes the identical dispatch and never reaches `Object.getPrototypeOf`. The added cost on the common path is a single `typeof`.

## Test plan

Added `describe('with a shadowed constructor property')` in `test/object.test.ts` (5 cases — all fail on `main`, pass after the fix):

- a plain object with an own `constructor` round-trips through `serialize`, `serializeAsync` and `toJSON`, preserving the `constructor` key and other properties;
- a null-prototype object with an own `constructor` stays null-prototype;
- a `Map` with an own `constructor` stays a `Map`.

`pnpm --filter seroval test` is green (792 tests); type-check output is unchanged from `main`.
