### PR TITLE
fix: preserve own `__proto__` properties through serialize

### DIFF
--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -630,6 +630,12 @@ function serializeProperty(
       }
       return '';
     }
+    // `__proto__` as an identifier or string key in an object literal is the
+    // prototype setter, not an own property; use a computed key so the
+    // round-trip preserves it as an actual own property.
+    if (key === '__proto__') {
+      return '["__proto__"]:' + serialize(ctx, val);
+    }
     return (isIdentifier ? key : '"' + key + '"') + ':' + serialize(ctx, val);
   }
   return '[' + serialize(ctx, key) + ']:' + serialize(ctx, val);

--- a/packages/seroval/test/object.test.ts
+++ b/packages/seroval/test/object.test.ts
@@ -536,4 +536,36 @@ describe('objects', () => {
       expect(back.example).toBe(EXAMPLE.example);
     });
   });
+  describe('with an own __proto__ property', () => {
+    // `JSON.parse` creates an own enumerable `__proto__` data property
+    // (not a prototype), as does any record with a `__proto__` field.
+    function makeProtoObject(): Record<string, unknown> {
+      return JSON.parse('{"__proto__":5,"value":42}') as Record<string, unknown>;
+    }
+    function expectPreserved(back: Record<string, unknown>): void {
+      const descriptor = Object.getOwnPropertyDescriptor(back, '__proto__');
+      expect(descriptor).toBeDefined();
+      expect(descriptor?.value).toBe(5);
+      expect(Object.getPrototypeOf(back)).toBe(Object.prototype);
+      expect(back.value).toBe(42);
+    }
+
+    it('supports serialize', () => {
+      expectPreserved(
+        deserialize<Record<string, unknown>>(serialize(makeProtoObject())),
+      );
+    });
+    it('supports serializeAsync', async () => {
+      expectPreserved(
+        deserialize<Record<string, unknown>>(
+          await serializeAsync(makeProtoObject()),
+        ),
+      );
+    });
+    it('supports toJSON', () => {
+      expectPreserved(
+        fromJSON<Record<string, unknown>>(toJSON(makeProtoObject())),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description

An own property named `__proto__` is silently dropped by `serialize`/`deserialize`, while `toJSON`/`fromJSON` keeps it — so the two paths disagree.

```js
import { serialize, deserialize, toJSON, fromJSON } from 'seroval';

// JSON.parse creates an own enumerable `__proto__` data property
const value = JSON.parse('{"__proto__": 5, "a": 1}');
Object.getOwnPropertyDescriptor(value, '__proto__'); // { value: 5, … }

serialize(value); // ({__proto__:5,a:1})
const back = deserialize(serialize(value));
Object.getOwnPropertyDescriptor(back, '__proto__'); // undefined  ← dropped

const json = fromJSON(toJSON(value));
Object.getOwnPropertyDescriptor(json, '__proto__'); // { value: 5, … }  ← kept
```

Objects with a `__proto__` key are common — `JSON.parse('{"__proto__": …}')`, and any record that happens to carry a `__proto__` field — so this is a real round-trip data loss for the sync/eval path.

### Root cause

`serializeProperty` emits string keys as `key: value` (identifier) or `"key": value` (quoted). For `__proto__`, both forms are the **prototype-setter** syntax in an object literal (`{ __proto__: x }` / `{ "__proto__": x }` set the prototype, not an own property), so the deserialized object never gets the property back. The same applies to the `Object.assign(Object.create(null), { __proto__: x })` form used for null-prototype objects.

### Fix

Emit a `__proto__` key with a **computed key** instead:

```js
{ ["__proto__"]: value }
```

A computed key is not the prototype-setter — it creates a genuine own `__proto__` property and leaves the prototype untouched. Every other key is unchanged, and the reconstruction is faithful for plain objects, `Object.create(null)` objects, and shared references alike.

## Test plan

### Before

- `deserialize(serialize(JSON.parse('{"__proto__":5,"value":42}')))` had no own `__proto__` property (`serialize`/`serializeAsync`), while `toJSON`/`fromJSON` retained it.

### After

- All three paths round-trip the own `__proto__` property (value preserved, prototype still `Object.prototype`, other keys intact).

Added `describe('with an own __proto__ property')` in `test/object.test.ts` (serialize / serializeAsync fail on `main`, toJSON already passed — they agree after the fix). `pnpm --filter seroval test` is green (661 tests).
