### PR TITLE
fix: preserve circular own `__proto__` properties through deferred assignment

### DIFF
--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -66,6 +66,7 @@ const enum AssignmentType {
   Add = 1,
   Set = 2,
   Delete = 3,
+  Define = 4,
 }
 
 interface IndexAssignment {
@@ -96,12 +97,23 @@ interface DeleteAssignment {
   v: undefined;
 }
 
+// Defines an own `__proto__` data property (see `createObjectAssign`).
+// `k` holds the serialized value; `v` is unused so this never participates
+// in the value-based merging done by `mergeAssignments`.
+interface DefineAssignment {
+  t: AssignmentType.Define;
+  s: string;
+  k: string;
+  v: undefined;
+}
+
 // Array of assignments to be done (used for recursion)
 type Assignment =
   | IndexAssignment
   | AddAssignment
   | SetAssignment
-  | DeleteAssignment;
+  | DeleteAssignment
+  | DefineAssignment;
 
 export interface FlaggedObject {
   type: SerovalObjectFlags;
@@ -118,6 +130,14 @@ function getAssignmentExpression(assignment: Assignment): string {
       return assignment.s + '.add(' + assignment.v + ')';
     case AssignmentType.Delete:
       return assignment.s + '.delete(' + assignment.k + ')';
+    case AssignmentType.Define:
+      return (
+        'Object.defineProperty(' +
+        assignment.s +
+        ',"__proto__",{value:' +
+        assignment.k +
+        ',configurable:!0,enumerable:!0,writable:!0})'
+      );
   }
 }
 
@@ -482,6 +502,19 @@ function createObjectAssign(
   key: string,
   value: string,
 ): void {
+  if (key === '__proto__') {
+    // `obj.__proto__ = x`, including the bracket form `obj["__proto__"] = x`,
+    // invokes the prototype setter rather than creating an own property.
+    // Define the property instead so the round-trip preserves it as an actual
+    // own property (matches the inline path in `serializeProperty`).
+    ctx.base.assignments.push({
+      t: AssignmentType.Define,
+      s: getRefParam(ctx, ref),
+      k: value,
+      v: NIL,
+    });
+    return;
+  }
   createAssignment(ctx.base, getRefParam(ctx, ref) + '.' + key, value);
 }
 

--- a/packages/seroval/test/object.test.ts
+++ b/packages/seroval/test/object.test.ts
@@ -568,4 +568,49 @@ describe('objects', () => {
       );
     });
   });
+  describe('with a circular own __proto__ property', () => {
+    // `parent.child` -> `child`, and `child`'s own enumerable `__proto__`
+    // data property holds a back-reference to `parent`. The back-reference
+    // forces `__proto__` through the deferred assignment path rather than
+    // the inline object literal.
+    function makeCircularProtoObject(): Record<string, unknown> {
+      const parent: Record<string, unknown> = {};
+      const child = JSON.parse('{"__proto__":0}') as Record<string, unknown>;
+      parent.child = child;
+      Object.defineProperty(child, '__proto__', {
+        value: parent,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      return parent;
+    }
+    function expectPreserved(back: Record<string, unknown>): void {
+      const child = back.child as Record<string, unknown>;
+      const descriptor = Object.getOwnPropertyDescriptor(child, '__proto__');
+      expect(descriptor).toBeDefined();
+      expect(descriptor?.value).toBe(back);
+      expect(Object.getPrototypeOf(child)).toBe(Object.prototype);
+    }
+
+    it('supports serialize', () => {
+      expectPreserved(
+        deserialize<Record<string, unknown>>(
+          serialize(makeCircularProtoObject()),
+        ),
+      );
+    });
+    it('supports serializeAsync', async () => {
+      expectPreserved(
+        deserialize<Record<string, unknown>>(
+          await serializeAsync(makeCircularProtoObject()),
+        ),
+      );
+    });
+    it('supports toJSON', () => {
+      expectPreserved(
+        fromJSON<Record<string, unknown>>(toJSON(makeCircularProtoObject())),
+      );
+    });
+  });
 });


### PR DESCRIPTION
#81 fixed the inline object-literal path so that an own `__proto__` property round-trips as a real own property instead of being applied as a prototype. The deferred-assignment path that `serializeProperty` uses for back-references was left on the old behavior.

When a property keyed `__proto__` holds a circular reference, `serializeProperty` takes the `isIndexedValueInStack` branch before reaching the `__proto__` check and emits the assignment through `createObjectAssign`, which produces `ref.__proto__ = value`. Both that and the bracket form `ref["__proto__"] = value` go through the prototype setter rather than creating an own property, so the value is lost and the object's prototype is changed.

```js
const parent = {};
const child = JSON.parse('{"__proto__":0}'); // own enumerable __proto__
parent.child = child;
Object.defineProperty(child, '__proto__', {
  value: parent, // back-reference -> deferred assignment
  configurable: true,
  enumerable: true,
  writable: true,
});

const back = deserialize(serialize(parent));
// before: back.child has no own `__proto__`, and its prototype is set to back
// after:  back.child.__proto__ is an own property === back, prototype stays Object.prototype
```

`createObjectAssign` now emits `Object.defineProperty(ref, "__proto__", { value, ... })` for that key. This matches the computed-key fix #81 made for the inline path and the `Object.defineProperty` route the deserializer already takes in `assignStringProperty` (which is why `toJSON`/`fromJSON` were already correct, and the change is only needed for the `serialize` output).

The new assignment type carries its value in `k` with `v` unset, so it never participates in the value-based merging in `mergeAssignments`.

Added a `with a circular own __proto__ property` block next to the existing `with an own __proto__ property` test, covering `serialize`, `serializeAsync`, and `toJSON`. Full suite passes (664).
