### PR TITLE
fix: use element length for bigint typed array views

### DIFF
--- a/packages/seroval/src/core/base-primitives.ts
+++ b/packages/seroval/src/core/base-primitives.ts
@@ -306,7 +306,7 @@ export function createBigIntTypedArrayNode(
     buffer,
     current.byteOffset,
     NIL,
-    current.byteLength,
+    current.length,
   );
 }
 

--- a/packages/seroval/test/__snapshots__/bigint-typed-array.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/bigint-typed-array.test.ts.snap
@@ -1,0 +1,147 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`bigint typed arrays > crossSerialize > scoped > supports bigint typed arrays 1`] = `
+"($R=>$R[0]=new BigInt64Array($R[1]=($R[2]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4))($R["example"])"
+`;
+
+exports[`bigint typed arrays > crossSerialize > supports bigint typed arrays 1`] = `
+"$R[0]=new BigInt64Array($R[1]=($R[2]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4)"
+`;
+
+exports[`bigint typed arrays > crossSerializeAsync > scoped > supports bigint typed arrays 1`] = `
+"($R=>$R[0]=Promise.resolve($R[1]=new BigInt64Array($R[2]=($R[3]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4)))($R["example"])"
+`;
+
+exports[`bigint typed arrays > crossSerializeAsync > supports bigint typed arrays 1`] = `
+"$R[0]=Promise.resolve($R[1]=new BigInt64Array($R[2]=($R[3]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4))"
+`;
+
+exports[`bigint typed arrays > crossSerializeStream > scoped > supports bigint typed arrays 1`] = `
+"($R=>$R[0]=($R[1]=($R[2]=() => {
+  const resolver = {
+    p: 0,
+    s: 0,
+    f: 0
+  };
+  resolver.p = new Promise((resolve, reject) => {
+    resolver.s = resolve;
+    resolver.f = reject;
+  });
+  return resolver;
+})()).p)($R["example"])"
+`;
+
+exports[`bigint typed arrays > crossSerializeStream > scoped > supports bigint typed arrays 2`] = `
+"($R=>($R[6]=(resolver, data) => {
+  resolver.s(data);
+  resolver.p.s = 1;
+  resolver.p.v = data;
+})($R[1],$R[3]=new BigInt64Array($R[4]=($R[5]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4)))($R["example"])"
+`;
+
+exports[`bigint typed arrays > crossSerializeStream > supports bigint typed arrays 1`] = `
+"$R[0]=($R[1]=($R[2]=() => {
+  const resolver = {
+    p: 0,
+    s: 0,
+    f: 0
+  };
+  resolver.p = new Promise((resolve, reject) => {
+    resolver.s = resolve;
+    resolver.f = reject;
+  });
+  return resolver;
+})()).p"
+`;
+
+exports[`bigint typed arrays > crossSerializeStream > supports bigint typed arrays 2`] = `
+"($R[6]=(resolver, data) => {
+  resolver.s(data);
+  resolver.p.s = 1;
+  resolver.p.v = data;
+})($R[1],$R[3]=new BigInt64Array($R[4]=($R[5]=(b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4))"
+`;
+
+exports[`bigint typed arrays > serialize > supports bigint typed arrays 1`] = `
+"new BigInt64Array(((b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4)"
+`;
+
+exports[`bigint typed arrays > serializeAsync > supports bigint typed arrays 1`] = `
+"Promise.resolve(new BigInt64Array(((b64) => {
+  const decoded = atob(b64);
+  const length = decoded.length;
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = decoded.charCodeAt(i);
+  };
+  return arr.buffer;
+})("AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8="),0,4))"
+`;
+
+exports[`bigint typed arrays > toCrossJSON > supports bigint typed arrays 1`] = `"{"t":16,"i":0,"c":"BigInt64Array","f":{"t":19,"i":1,"s":"AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8=","f":{"t":26,"i":2,"s":5}},"b":0,"l":4}"`;
+
+exports[`bigint typed arrays > toCrossJSONAsync > supports bigint typed arrays 1`] = `"{"t":12,"i":0,"s":1,"f":{"t":16,"i":1,"c":"BigInt64Array","f":{"t":19,"i":2,"s":"AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8=","f":{"t":26,"i":3,"s":5}},"b":0,"l":4}}"`;
+
+exports[`bigint typed arrays > toCrossJSONStream > supports bigint typed arrays 1`] = `"{"t":22,"i":0,"s":1,"f":{"t":26,"i":2,"s":1}}"`;
+
+exports[`bigint typed arrays > toCrossJSONStream > supports bigint typed arrays 2`] = `"{"t":23,"i":1,"a":[{"t":26,"i":6,"s":2},{"t":16,"i":3,"c":"BigInt64Array","f":{"t":19,"i":4,"s":"AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8=","f":{"t":26,"i":5,"s":5}},"b":0,"l":4}]}"`;
+
+exports[`bigint typed arrays > toJSON > supports bigint typed arrays 1`] = `"{"t":{"t":16,"i":0,"c":"BigInt64Array","f":{"t":19,"i":1,"s":"AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8=","f":{"t":26,"i":2,"s":5}},"b":0,"l":4},"f":63,"m":[]}"`;
+
+exports[`bigint typed arrays > toJSONAsync > supports bigint typed arrays 1`] = `"{"t":{"t":12,"i":0,"s":1,"f":{"t":16,"i":1,"c":"BigInt64Array","f":{"t":19,"i":2,"s":"AQAAAAAA4P////////8fAAAAAAAAAAAA//////////8=","f":{"t":26,"i":3,"s":5}},"b":0,"l":4}},"f":63,"m":[]}"`;

--- a/packages/seroval/test/bigint-typed-array.test.ts
+++ b/packages/seroval/test/bigint-typed-array.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  crossSerialize,
+  crossSerializeAsync,
+  crossSerializeStream,
+  deserialize,
+  fromCrossJSON,
+  fromJSON,
+  serialize,
+  serializeAsync,
+  toCrossJSON,
+  toCrossJSONAsync,
+  toCrossJSONStream,
+  toJSON,
+  toJSONAsync,
+} from '../src';
+
+const EXAMPLE = new BigInt64Array([
+  -9007199254740991n,
+  9007199254740991n,
+  0n,
+  -1n,
+]);
+
+describe('bigint typed arrays', () => {
+  describe('serialize', () => {
+    it('supports bigint typed arrays', () => {
+      const result = serialize(EXAMPLE);
+      expect(result).toMatchSnapshot();
+      const back = deserialize<typeof EXAMPLE>(result);
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('serializeAsync', () => {
+    it('supports bigint typed arrays', async () => {
+      const result = await serializeAsync(Promise.resolve(EXAMPLE));
+      expect(result).toMatchSnapshot();
+      const back = await deserialize<Promise<typeof EXAMPLE>>(result);
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('toJSON', () => {
+    it('supports bigint typed arrays', () => {
+      const result = toJSON(EXAMPLE);
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = fromJSON<typeof EXAMPLE>(result);
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('toJSONAsync', () => {
+    it('supports bigint typed arrays', async () => {
+      const result = await toJSONAsync(Promise.resolve(EXAMPLE));
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = await fromJSON<Promise<typeof EXAMPLE>>(result);
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('crossSerialize', () => {
+    it('supports bigint typed arrays', () => {
+      const result = crossSerialize(EXAMPLE);
+      expect(result).toMatchSnapshot();
+    });
+    describe('scoped', () => {
+      it('supports bigint typed arrays', () => {
+        const result = crossSerialize(EXAMPLE, { scopeId: 'example' });
+        expect(result).toMatchSnapshot();
+      });
+    });
+  });
+  describe('crossSerializeAsync', () => {
+    it('supports bigint typed arrays', async () => {
+      const result = await crossSerializeAsync(Promise.resolve(EXAMPLE));
+      expect(result).toMatchSnapshot();
+    });
+    describe('scoped', () => {
+      it('supports bigint typed arrays', async () => {
+        const result = await crossSerializeAsync(Promise.resolve(EXAMPLE), {
+          scopeId: 'example',
+        });
+        expect(result).toMatchSnapshot();
+      });
+    });
+  });
+  describe('crossSerializeStream', () => {
+    it('supports bigint typed arrays', async () =>
+      new Promise<void>((resolve, reject) => {
+        crossSerializeStream(Promise.resolve(EXAMPLE), {
+          onSerialize(data) {
+            expect(data).toMatchSnapshot();
+          },
+          onDone() {
+            resolve();
+          },
+          onError(error) {
+            reject(error);
+          },
+        });
+      }));
+    describe('scoped', () => {
+      it('supports bigint typed arrays', async () =>
+        new Promise<void>((resolve, reject) => {
+          crossSerializeStream(Promise.resolve(EXAMPLE), {
+            scopeId: 'example',
+            onSerialize(data) {
+              expect(data).toMatchSnapshot();
+            },
+            onDone() {
+              resolve();
+            },
+            onError(error) {
+              reject(error);
+            },
+          });
+        }));
+    });
+  });
+  describe('toCrossJSON', () => {
+    it('supports bigint typed arrays', () => {
+      const result = toCrossJSON(EXAMPLE);
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = fromCrossJSON<typeof EXAMPLE>(result, {
+        refs: new Map(),
+      });
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('toCrossJSONAsync', () => {
+    it('supports bigint typed arrays', async () => {
+      const result = await toCrossJSONAsync(Promise.resolve(EXAMPLE));
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = await fromCrossJSON<Promise<typeof EXAMPLE>>(result, {
+        refs: new Map(),
+      });
+      expect(back).toBeInstanceOf(BigInt64Array);
+      expect(back.length).toBe(EXAMPLE.length);
+      expect(back[0]).toBe(EXAMPLE[0]);
+      expect(back[1]).toBe(EXAMPLE[1]);
+      expect(back[2]).toBe(EXAMPLE[2]);
+      expect(back[3]).toBe(EXAMPLE[3]);
+    });
+  });
+  describe('toCrossJSONStream', () => {
+    it('supports bigint typed arrays', async () =>
+      new Promise<void>((resolve, reject) => {
+        toCrossJSONStream(Promise.resolve(EXAMPLE), {
+          onParse(data) {
+            expect(JSON.stringify(data)).toMatchSnapshot();
+          },
+          onDone() {
+            resolve();
+          },
+          onError(error) {
+            reject(error);
+          },
+        });
+      }));
+  });
+});


### PR DESCRIPTION
`createBigIntTypedArrayNode` stores `byteLength` in the length field, but the serializer and deserializer pass that field as the element count to the typed array constructor. Deserializing any non-empty `BigInt64Array` or `BigUint64Array` throws `RangeError: Invalid typed array length`. `createTypedArrayNode` correctly uses `length`; only the BigInt variant diverged.

This uses `length`, matching `createTypedArrayNode`. Adds a test covering all serialize and deserialize paths.
