### PR TITLE
fix: unescape regexp source in the serialized output

### DIFF
--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -21,7 +21,7 @@ import { GLOBAL_CONTEXT_REFERENCES, REFERENCES_KEY } from '../keys';
 import type { PluginAccessOptions } from '../plugin';
 import { SerovalMode } from '../plugin';
 import { SPECIAL_REF_STRING } from '../special-reference';
-import { serializeString } from '../string';
+import { deserializeString, serializeString } from '../string';
 import type {
   SerovalAggregateErrorNode,
   SerovalArrayBufferNode,
@@ -856,7 +856,7 @@ function serializeRegExp(
   node: SerovalRegExpNode,
 ): string {
   if (ctx.base.features & Feature.RegExp) {
-    return '/' + node.c + '/' + node.m;
+    return '/' + deserializeString(node.c) + '/' + node.m;
   }
   throw new SerovalUnsupportedNodeError(node);
 }

--- a/packages/seroval/test/__snapshots__/regexp.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/regexp.test.ts.snap
@@ -69,3 +69,15 @@ exports[`RegExp > toCrossJSONStream > supports RegExp 2`] = `"{"t":23,"i":1,"a":
 exports[`RegExp > toJSON > supports RegExp 1`] = `"{"t":{"t":6,"i":0,"c":"[a-z0-9]+","m":"i"},"f":63,"m":[]}"`;
 
 exports[`RegExp > toJSONAsync > supports RegExp 1`] = `"{"t":{"t":12,"i":0,"s":1,"f":{"t":6,"i":1,"c":"[a-z0-9]+","m":"i"}},"f":63,"m":[]}"`;
+
+exports[`RegExp with escaped source > serialize > supports escaped source 1`] = `"/\\d+\\.\\d+\\s?\\/\\w*/g"`;
+
+exports[`RegExp with escaped source > serializeAsync > supports escaped source 1`] = `"Promise.resolve(/\\d+\\.\\d+\\s?\\/\\w*/g)"`;
+
+exports[`RegExp with escaped source > toCrossJSON > supports escaped source 1`] = `"{"t":6,"i":0,"c":"\\\\\\\\d+\\\\\\\\.\\\\\\\\d+\\\\\\\\s?\\\\\\\\/\\\\\\\\w*","m":"g"}"`;
+
+exports[`RegExp with escaped source > toCrossJSONAsync > supports escaped source 1`] = `"{"t":12,"i":0,"s":1,"f":{"t":6,"i":1,"c":"\\\\\\\\d+\\\\\\\\.\\\\\\\\d+\\\\\\\\s?\\\\\\\\/\\\\\\\\w*","m":"g"}}"`;
+
+exports[`RegExp with escaped source > toJSON > supports escaped source 1`] = `"{"t":{"t":6,"i":0,"c":"\\\\\\\\d+\\\\\\\\.\\\\\\\\d+\\\\\\\\s?\\\\\\\\/\\\\\\\\w*","m":"g"},"f":63,"m":[]}"`;
+
+exports[`RegExp with escaped source > toJSONAsync > supports escaped source 1`] = `"{"t":{"t":12,"i":0,"s":1,"f":{"t":6,"i":1,"c":"\\\\\\\\d+\\\\\\\\.\\\\\\\\d+\\\\\\\\s?\\\\\\\\/\\\\\\\\w*","m":"g"}},"f":63,"m":[]}"`;

--- a/packages/seroval/test/regexp.test.ts
+++ b/packages/seroval/test/regexp.test.ts
@@ -17,6 +17,8 @@ import {
 
 const EXAMPLE = /[a-z0-9]+/i;
 
+const EXAMPLE_ESCAPED = /\d+\.\d+\s?\/\w*/g;
+
 describe('RegExp', () => {
   describe('serialize', () => {
     it('supports RegExp', () => {
@@ -150,5 +152,75 @@ describe('RegExp', () => {
           },
         });
       }));
+  });
+});
+
+describe('RegExp with escaped source', () => {
+  describe('serialize', () => {
+    it('supports escaped source', () => {
+      const result = serialize(EXAMPLE_ESCAPED);
+      expect(result).toMatchSnapshot();
+      const back = deserialize<typeof EXAMPLE_ESCAPED>(result);
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
+  });
+  describe('serializeAsync', () => {
+    it('supports escaped source', async () => {
+      const result = await serializeAsync(Promise.resolve(EXAMPLE_ESCAPED));
+      expect(result).toMatchSnapshot();
+      const back = await deserialize<Promise<typeof EXAMPLE_ESCAPED>>(result);
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
+  });
+  describe('toJSON', () => {
+    it('supports escaped source', () => {
+      const result = toJSON(EXAMPLE_ESCAPED);
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = fromJSON<typeof EXAMPLE_ESCAPED>(result);
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
+  });
+  describe('toJSONAsync', () => {
+    it('supports escaped source', async () => {
+      const result = await toJSONAsync(Promise.resolve(EXAMPLE_ESCAPED));
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = await fromJSON<Promise<typeof EXAMPLE_ESCAPED>>(result);
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
+  });
+  describe('toCrossJSON', () => {
+    it('supports escaped source', () => {
+      const result = toCrossJSON(EXAMPLE_ESCAPED);
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = fromCrossJSON<typeof EXAMPLE_ESCAPED>(result, {
+        refs: new Map(),
+      });
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
+  });
+  describe('toCrossJSONAsync', () => {
+    it('supports escaped source', async () => {
+      const result = await toCrossJSONAsync(Promise.resolve(EXAMPLE_ESCAPED));
+      expect(JSON.stringify(result)).toMatchSnapshot();
+      const back = await fromCrossJSON<Promise<typeof EXAMPLE_ESCAPED>>(
+        result,
+        {
+          refs: new Map(),
+        },
+      );
+      expect(back).toBeInstanceOf(RegExp);
+      expect(back.source).toBe(EXAMPLE_ESCAPED.source);
+      expect(String(back)).toBe(String(EXAMPLE_ESCAPED));
+    });
   });
 });


### PR DESCRIPTION
`createRegExpNode` stores the pattern via `serializeString`, which doubles backslashes for a string-literal context. `serializeRegExp` dropped that escaped text straight into a regexp literal, so `serialize(/\d+/g)` produced `/\\d+/g` and deserialized to a regexp matching a literal backslash, or threw a syntax error when the source contained an escaped delimiter. The JSON deserializer reverses this via `deserializeString`; the eval serializer did not.

This reverses the escaping before emitting the literal, matching what the JSON deserializer already does. The JSON wire format is unchanged. Adds escaped-source cases to the regexp test.
