### PR TITLE
fix: make serialized constructors survive keep-names bundling

### DIFF
--- a/.changeset/keep-names-serialized-constructors.md
+++ b/.changeset/keep-names-serialized-constructors.md
@@ -1,0 +1,6 @@
+---
+"seroval": patch
+"seroval-plugins": patch
+---
+
+Serialized constructors now survive name-preserving bundler transforms (e.g. esbuild `keepNames`, which some platforms apply to hosted code downstream of the app's own build): every nested function in a `toString()`-serialized constructor uses method shorthand, so no bundle-scoped name helper leaks into payloads evaluated in realms that never loaded the bundle.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/__snapshots__/*.snap linguist-generated

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -15,8 +15,9 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@vitest/ui": "^4.0.6",
-    "tsdown": "^0.22.14",
+    "esbuild": "^0.28.1",
     "seroval": "1.5.5",
+    "tsdown": "^0.22.14",
     "tslib": "^2.8.1",
     "typescript": "^7.0.2",
     "vitest": "^4.0.6"

--- a/packages/plugins/tests/web/__snapshots__/readable-stream.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/readable-stream.test.ts.snap
@@ -2,18 +2,18 @@
 
 exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream 1`] = `
 "($R=>$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -90,18 +90,18 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 
 exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream errors 1`] = `
 "($R=>$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -178,18 +178,18 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 
 exports[`ReadableStream > crossSerializeAsync > supports ReadableStream 1`] = `
 "$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -266,18 +266,18 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream 1`] = `
 
 exports[`ReadableStream > crossSerializeAsync > supports ReadableStream errors 1`] = `
 "$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -354,18 +354,18 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream errors 1
 
 exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStream 1`] = `
 "($R=>$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -450,18 +450,18 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 
 exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStream errors 1`] = `
 "($R=>$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -540,18 +540,18 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 
 exports[`ReadableStream > crossSerializeStream > supports ReadableStream 1`] = `
 "$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -636,18 +636,18 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream 5`] = `
 
 exports[`ReadableStream > crossSerializeStream > supports ReadableStream errors 1`] = `
 "$R[0]=($R[1]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -726,18 +726,18 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream errors 
 
 exports[`ReadableStream > serializeAsync > supports ReadableStream 1`] = `
 "(h=>((stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -814,18 +814,18 @@ exports[`ReadableStream > serializeAsync > supports ReadableStream 1`] = `
 
 exports[`ReadableStream > serializeAsync > supports ReadableStream errors 1`] = `
 "(h=>((stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {

--- a/packages/plugins/tests/web/__snapshots__/request.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/request.test.ts.snap
@@ -38,18 +38,18 @@ exports[`Request > crossSerializeAsync > supports already read Request 1`] = `
 
 exports[`Request > crossSerializeStream > scoped > supports Request 1`] = `
 "($R=>$R[0]=new Request("http://localhost:3000/",$R[1]={body:$R[2]=($R[3]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -140,18 +140,18 @@ exports[`Request > crossSerializeStream > scoped > supports Request 3`] = `"($R=
 
 exports[`Request > crossSerializeStream > supports Request 1`] = `
 "$R[0]=new Request("http://localhost:3000/",$R[1]={body:$R[2]=($R[3]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {

--- a/packages/plugins/tests/web/__snapshots__/response.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/response.test.ts.snap
@@ -26,18 +26,18 @@ exports[`Response > crossSerializeAsync > supports Response 1`] = `
 
 exports[`Response > crossSerializeStream > scoped > supports Response 1`] = `
 "($R=>$R[0]=new Response($R[1]=($R[2]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {
@@ -128,18 +128,18 @@ exports[`Response > crossSerializeStream > scoped > supports Response 3`] = `"($
 
 exports[`Response > crossSerializeStream > supports Response 1`] = `
 "$R[0]=new Response($R[1]=($R[2]=(stream) => new ReadableStream({
-  start: (controller) => {
+  start(controller) {
     stream.on({
-      next: (value) => {
+      next(value) {
         try {
           controller.enqueue(value);
         } catch (_error) {
         }
       },
-      throw: (value) => {
+      throw(value) {
         controller.error(value);
       },
-      return: () => {
+      return() {
         try {
           controller.close();
         } catch (_error) {

--- a/packages/plugins/tests/web/keep-names.test.ts
+++ b/packages/plugins/tests/web/keep-names.test.ts
@@ -1,0 +1,133 @@
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/lxsmnsyc/seroval/issues/87
+//
+// Same setup as seroval's keep-names.test.ts: bundle the library with
+// esbuild keepNames + minify (as a hosting platform may do downstream of the
+// app's own build), generate payloads inside that bundle, then evaluate AND
+// consume them in a scope that only sees globals — the receiving realm never
+// loaded the bundle, so any bundle-scoped helper reference throws.
+
+const FIXTURE = `
+import { crossSerializeStream, serializeAsync } from 'seroval';
+import AbortSignalPlugin from '../../web/abort-signal';
+import FormDataPlugin from '../../web/form-data';
+import ReadableStreamPlugin from '../../web/readable-stream';
+
+function collectAbortSignalChunks(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    const chunks: string[] = [];
+    crossSerializeStream(controller.signal, {
+      plugins: [AbortSignalPlugin],
+      onSerialize(data) {
+        chunks.push(data);
+      },
+      onDone() {
+        resolve(chunks);
+      },
+      onError(error) {
+        reject(error);
+      },
+    });
+    controller.abort('aborted!');
+  });
+}
+
+export async function getPayloads() {
+  const stream = new ReadableStream({
+    start(controller): void {
+      controller.enqueue('foo');
+      controller.enqueue('bar');
+      controller.close();
+    },
+  });
+  const formData = new FormData();
+  formData.append('hello', 'world');
+  return {
+    readableStream: await serializeAsync(stream, {
+      plugins: [ReadableStreamPlugin],
+    }),
+    formData: await serializeAsync(formData, {
+      plugins: [FormDataPlugin],
+    }),
+    abortSignalChunks: await collectAbortSignalChunks(),
+  };
+}
+`;
+
+interface Payloads {
+  readableStream: string;
+  formData: string;
+  abortSignalChunks: string[];
+}
+
+let cached: Promise<Payloads> | undefined;
+
+function getBundledPayloads(): Promise<Payloads> {
+  cached ||= bundleAndRun();
+  return cached;
+}
+
+async function bundleAndRun(): Promise<Payloads> {
+  const result = await build({
+    stdin: {
+      contents: FIXTURE,
+      resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+      loader: 'ts',
+    },
+    // The devDependency on seroval resolves to the registry, but this suite
+    // guards the workspace code — bundle against the local build (CI builds
+    // all packages before running tests).
+    alias: {
+      seroval: fileURLToPath(
+        new URL('../../../seroval/dist/index.js', import.meta.url),
+      ),
+    },
+    bundle: true,
+    keepNames: true,
+    minify: true,
+    format: 'esm',
+    platform: 'node',
+    write: false,
+  });
+  const code = result.outputFiles[0].text;
+  const mod = await import(
+    `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
+  );
+  return mod.getPayloads();
+}
+
+function evaluate<T>(payload: string): T {
+  return new Function(`return (${payload})`)() as T;
+}
+
+describe('keep-names bundled payloads', () => {
+  it('supports ReadableStream', async () => {
+    const payloads = await getBundledPayloads();
+    const back = evaluate<ReadableStream<string>>(payloads.readableStream);
+    const reader = back.getReader();
+    expect(await reader.read()).toMatchObject({ done: false, value: 'foo' });
+    expect(await reader.read()).toMatchObject({ done: false, value: 'bar' });
+    expect(await reader.read()).toMatchObject({ done: true });
+  });
+  it('supports FormData', async () => {
+    const payloads = await getBundledPayloads();
+    const back = evaluate<FormData>(payloads.formData);
+    expect(back.get('hello')).toBe('world');
+  });
+  it('supports AbortSignal', async () => {
+    const payloads = await getBundledPayloads();
+    const $R: unknown[] = [];
+    new Function('$R', payloads.abortSignalChunks.join(';\n'))($R);
+    const back = $R[0] as AbortSignal;
+    // the deserialized promise aborts the controller in a microtask
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+    expect(back.aborted).toBe(true);
+    expect(back.reason).toBe('aborted!');
+  });
+});

--- a/packages/plugins/web/readable-stream.ts
+++ b/packages/plugins/web/readable-stream.ts
@@ -3,21 +3,26 @@ import { createPlugin, createStream } from 'seroval';
 
 const READABLE_STREAM_FACTORY = {};
 
+// Serialized via toString() — only use method shorthand for nested functions.
+// Their name comes from the property key at runtime, so name-preserving
+// transforms (esbuild keepNames) have nothing to wrap; any other shape gets
+// rewritten to call a bundle-scoped helper that does not exist in the
+// receiving realm. https://github.com/lxsmnsyc/seroval/issues/87
 const READABLE_STREAM_FACTORY_CONSTRUCTOR = (stream: Stream<unknown>) =>
   new ReadableStream({
-    start: controller => {
+    start(controller) {
       stream.on({
-        next: value => {
+        next(value) {
           try {
             controller.enqueue(value);
           } catch (_error) {
             // no-op
           }
         },
-        throw: value => {
+        throw(value) {
           controller.error(value);
         },
-        return: () => {
+        return() {
           try {
             controller.close();
           } catch (_error) {

--- a/packages/seroval/package.json
+++ b/packages/seroval/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@vitest/ui": "^4.0.6",
+    "esbuild": "^0.28.1",
     "temporal-polyfill": "^0.3.2",
     "ts-prune": "^0.10.3",
     "tsdown": "^0.22.14",

--- a/packages/seroval/src/core/constructors.ts
+++ b/packages/seroval/src/core/constructors.ts
@@ -53,73 +53,79 @@ interface StreamListener<T> {
   return(value: T): void;
 }
 
+// Serialized via toString() — every nested function must be an object method
+// in shorthand form. Shorthand methods take their name from the property key
+// at runtime, so name-preserving transforms (esbuild keepNames) emit nothing
+// for them; arrows, function expressions and local function declarations all
+// get rewritten to call a bundle-scoped helper that does not exist in the
+// receiving realm. https://github.com/lxsmnsyc/seroval/issues/87
 export const STREAM_CONSTRUCTOR = () => {
   const buffer: unknown[] = [];
   const listeners: StreamListener<unknown>[] = [];
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (
-    value: unknown,
-    mode: keyof StreamListener<unknown>,
-    x?: number,
-  ) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value: unknown, mode: keyof StreamListener<unknown>, x?: number) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (
-    listener: StreamListener<unknown>,
-    x?: number,
-    z?: number,
-    current?: unknown,
-  ) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? 'return' : 'throw'](current);
-      } else {
-        listener.next(current);
+    },
+    up(
+      listener: StreamListener<unknown>,
+      x?: number,
+      z?: number,
+      current?: unknown,
+    ) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? 'return' : 'throw'](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener: StreamListener<unknown>, temp?: number) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    }
-    up(listener);
-    return () => {
+    },
+    on(listener: StreamListener<unknown>, temp?: number) {
       if (alive) {
-        listeners[temp!] = listeners[count];
-        listeners[count--] = undefined as any;
+        temp = count++;
+        listeners[temp] = listener;
       }
-    };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp!] = listeners[count];
+          listeners[count--] = undefined as any;
+        }
+      };
+    },
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener: StreamListener<unknown>) => on(listener),
-    next: (value: unknown) => {
+    on(listener: StreamListener<unknown>) {
+      return internal.on(listener);
+    },
+    next(value: unknown) {
       if (alive) {
         buffer.push(value);
-        flush(value, 'next');
+        internal.flush(value, 'next');
       }
     },
-    throw: (value: unknown) => {
+    throw(value: unknown) {
       if (alive) {
         buffer.push(value);
-        flush(value, 'throw');
+        internal.flush(value, 'throw');
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value: unknown) => {
+    return(value: unknown) {
       if (alive) {
         buffer.push(value);
-        flush(value, 'return');
+        internal.flush(value, 'return');
         alive = false;
         success = true;
         listeners.length = 0;
@@ -131,12 +137,16 @@ export const STREAM_CONSTRUCTOR = () => {
 export const SERIALIZED_STREAM_CONSTRUCTOR =
   /* @__PURE__ */ STREAM_CONSTRUCTOR.toString();
 
+// Serialized via toString() — nested functions must be shorthand methods
+// (see STREAM_CONSTRUCTOR).
 export const ITERATOR_CONSTRUCTOR =
   (symbol: symbol) => (sequence: Sequence) => () => {
     let index = 0;
     const instance = {
-      [symbol]: () => instance,
-      next: () => {
+      [symbol]() {
+        return instance;
+      },
+      next() {
         if (index > sequence.d) {
           return {
             done: true,
@@ -160,6 +170,8 @@ export const ITERATOR_CONSTRUCTOR =
 export const SERIALIZED_ITERATOR_CONSTRUCTOR =
   /* @__PURE__ */ ITERATOR_CONSTRUCTOR.toString();
 
+// Serialized via toString() — nested functions must be shorthand methods
+// (see STREAM_CONSTRUCTOR).
 export const ASYNC_ITERATOR_CONSTRUCTOR =
   (symbol: symbol, createPromise: typeof PROMISE_CONSTRUCTOR) =>
   (stream: Stream<unknown>) =>
@@ -169,46 +181,50 @@ export const ASYNC_ITERATOR_CONSTRUCTOR =
     let isThrow = false;
     const buffer: unknown[] = [];
     const pending: PromiseConstructorResolver[] = [];
-    const finalize = (i = 0, len = pending.length) => {
-      for (; i < len; i++) {
-        pending[i].s({
-          done: true,
-          value: undefined,
-        });
-      }
+    const internal = {
+      finalize(i = 0, len = pending.length) {
+        for (; i < len; i++) {
+          pending[i].s({
+            done: true,
+            value: undefined,
+          });
+        }
+      },
     };
     stream.on({
-      next: value => {
+      next(value) {
         const temp = pending.shift();
         if (temp) {
           temp.s({ done: false, value });
         }
         buffer.push(value);
       },
-      throw: value => {
+      throw(value) {
         const temp = pending.shift();
         if (temp) {
           temp.f(value);
         }
-        finalize();
+        internal.finalize();
         doneAt = buffer.length;
         isThrow = true;
         buffer.push(value);
       },
-      return: value => {
+      return(value) {
         const temp = pending.shift();
         if (temp) {
           temp.s({ done: true, value });
         }
-        finalize();
+        internal.finalize();
         doneAt = buffer.length;
         buffer.push(value);
       },
     });
 
     const instance = {
-      [symbol]: () => instance,
-      next: () => {
+      [symbol]() {
+        return instance;
+      },
+      next() {
         if (doneAt === -1) {
           const index = count++;
           if (index >= buffer.length) {

--- a/packages/seroval/test/__snapshots__/async-iterable.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/async-iterable.test.ts.snap
@@ -18,45 +18,49 @@ exports[`AsyncIterable > crossSerializeAsync > scoped > supports AsyncIterables 
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -99,58 +103,62 @@ exports[`AsyncIterable > crossSerializeAsync > scoped > supports AsyncIterables 
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -178,45 +186,49 @@ exports[`AsyncIterable > crossSerializeAsync > supports AsyncIterables 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -259,58 +271,62 @@ exports[`AsyncIterable > crossSerializeAsync > supports AsyncIterables 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -338,45 +354,49 @@ exports[`AsyncIterable > crossSerializeStream > scoped > supports AsyncIterables
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -419,58 +439,62 @@ exports[`AsyncIterable > crossSerializeStream > scoped > supports AsyncIterables
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -506,45 +530,49 @@ exports[`AsyncIterable > crossSerializeStream > supports AsyncIterables 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -587,58 +615,62 @@ exports[`AsyncIterable > crossSerializeStream > supports AsyncIterables 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -674,45 +706,49 @@ exports[`AsyncIterable > serializeAsync > supports AsyncIterables 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -755,58 +791,62 @@ exports[`AsyncIterable > serializeAsync > supports AsyncIterables 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;

--- a/packages/seroval/test/__snapshots__/frozen-object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/frozen-object.test.ts.snap
@@ -6,8 +6,10 @@ exports[`frozen object > crossSerialize > scoped > supports Symbol.iterator 1`] 
 "($R=>($R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -37,8 +39,10 @@ exports[`frozen object > crossSerialize > supports Symbol.iterator 1`] = `
 "($R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -82,45 +86,49 @@ exports[`frozen object > crossSerializeAsync > scoped > supports Symbol.asyncIte
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -163,58 +171,62 @@ exports[`frozen object > crossSerializeAsync > scoped > supports Symbol.asyncIte
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -228,8 +240,10 @@ exports[`frozen object > crossSerializeAsync > scoped > supports Symbol.iterator
 "($R=>($R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -273,45 +287,49 @@ exports[`frozen object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -354,58 +372,62 @@ exports[`frozen object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -419,8 +441,10 @@ exports[`frozen object > crossSerializeAsync > supports Symbol.iterator 1`] = `
 "($R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -485,45 +509,49 @@ exports[`frozen object > crossSerializeStream > scoped > supports Symbol.asyncIt
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -566,58 +594,62 @@ exports[`frozen object > crossSerializeStream > scoped > supports Symbol.asyncIt
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -658,8 +690,10 @@ exports[`frozen object > crossSerializeStream > scoped > supports Symbol.iterato
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -747,45 +781,49 @@ exports[`frozen object > crossSerializeStream > supports Symbol.asyncIterator 1`
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -828,58 +866,62 @@ exports[`frozen object > crossSerializeStream > supports Symbol.asyncIterator 1`
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -920,8 +962,10 @@ exports[`frozen object > crossSerializeStream > supports Symbol.iterator 2`] = `
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -974,8 +1018,10 @@ exports[`frozen object > serialize > supports Symbol.iterator 1`] = `
 "((h,j)=>(h={[j=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -1019,45 +1065,49 @@ exports[`frozen object > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -1100,58 +1150,62 @@ exports[`frozen object > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -1165,8 +1219,10 @@ exports[`frozen object > serializeAsync > supports Symbol.iterator 1`] = `
 "((h,j,k)=>(k=Promise.resolve(h={[j=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,

--- a/packages/seroval/test/__snapshots__/iterable.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/iterable.test.ts.snap
@@ -4,8 +4,10 @@ exports[`Iterable > crossSerialize > scoped > supports Iterables 1`] = `
 "($R=>$R[0]={title:"Hello World",[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -31,8 +33,10 @@ exports[`Iterable > crossSerialize > supports Iterables 1`] = `
 "($R[0]={title:"Hello World",[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -58,8 +62,10 @@ exports[`Iterable > crossSerializeAsync > scoped > supports Iterables 1`] = `
 "($R=>$R[0]=Promise.resolve($R[1]={title:"Hello World",[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -85,8 +91,10 @@ exports[`Iterable > crossSerializeAsync > supports Iterables 1`] = `
 "$R[0]=Promise.resolve($R[1]={title:"Hello World",[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -131,8 +139,10 @@ exports[`Iterable > crossSerializeStream > scoped > supports Iterables 2`] = `
 })($R[1],$R[3]={title:"Hello World",[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -177,8 +187,10 @@ exports[`Iterable > crossSerializeStream > supports Iterables 2`] = `
 })($R[1],$R[3]={title:"Hello World",[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -204,8 +216,10 @@ exports[`Iterable > serialize > supports Iterables 1`] = `
 "(h=>({title:"Hello World",[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -231,8 +245,10 @@ exports[`Iterable > serializeAsync > supports Iterables 1`] = `
 "(h=>Promise.resolve({title:"Hello World",[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,

--- a/packages/seroval/test/__snapshots__/null-constructor.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/null-constructor.test.ts.snap
@@ -12,8 +12,10 @@ exports[`null-constructor > crossSerialize > scoped > supports Symbol.iterator 1
 "($R=>$R[0]=Object.assign(Object.create(null),{[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -43,8 +45,10 @@ exports[`null-constructor > crossSerialize > supports Symbol.iterator 1`] = `
 "$R[0]=Object.assign(Object.create(null),{[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -88,45 +92,49 @@ exports[`null-constructor > crossSerializeAsync > scoped > supports Symbol.async
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -169,58 +177,62 @@ exports[`null-constructor > crossSerializeAsync > scoped > supports Symbol.async
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -234,8 +246,10 @@ exports[`null-constructor > crossSerializeAsync > scoped > supports Symbol.itera
 "($R=>$R[0]=Promise.resolve($R[1]=Object.assign(Object.create(null),{[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -279,45 +293,49 @@ exports[`null-constructor > crossSerializeAsync > supports Symbol.asyncIterator 
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -360,58 +378,62 @@ exports[`null-constructor > crossSerializeAsync > supports Symbol.asyncIterator 
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -425,8 +447,10 @@ exports[`null-constructor > crossSerializeAsync > supports Symbol.iterator 1`] =
 "$R[0]=Promise.resolve($R[1]=Object.assign(Object.create(null),{[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -491,45 +515,49 @@ exports[`null-constructor > crossSerializeStream > scoped > supports Symbol.asyn
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -572,58 +600,62 @@ exports[`null-constructor > crossSerializeStream > scoped > supports Symbol.asyn
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -664,8 +696,10 @@ exports[`null-constructor > crossSerializeStream > scoped > supports Symbol.iter
 })($R[1],$R[3]=Object.assign(Object.create(null),{[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -753,45 +787,49 @@ exports[`null-constructor > crossSerializeStream > supports Symbol.asyncIterator
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -834,58 +872,62 @@ exports[`null-constructor > crossSerializeStream > supports Symbol.asyncIterator
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -926,8 +968,10 @@ exports[`null-constructor > crossSerializeStream > supports Symbol.iterator 2`] 
 })($R[1],$R[3]=Object.assign(Object.create(null),{[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -980,8 +1024,10 @@ exports[`null-constructor > serialize > supports Symbol.iterator 1`] = `
 "(h=>Object.assign(Object.create(null),{[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -1025,45 +1071,49 @@ exports[`null-constructor > serializeAsync > supports Symbol.asyncIterator 1`] =
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -1106,58 +1156,62 @@ exports[`null-constructor > serializeAsync > supports Symbol.asyncIterator 1`] =
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -1171,8 +1225,10 @@ exports[`null-constructor > serializeAsync > supports Symbol.iterator 1`] = `
 "(h=>Promise.resolve(Object.assign(Object.create(null),{[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,

--- a/packages/seroval/test/__snapshots__/object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/object.test.ts.snap
@@ -12,8 +12,10 @@ exports[`objects > crossSerialize > scoped > supports Symbol.iterator 1`] = `
 "($R=>$R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -43,8 +45,10 @@ exports[`objects > crossSerialize > supports Symbol.iterator 1`] = `
 "($R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -88,45 +92,49 @@ exports[`objects > crossSerializeAsync > scoped > supports Symbol.asyncIterator 
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -169,58 +177,62 @@ exports[`objects > crossSerializeAsync > scoped > supports Symbol.asyncIterator 
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -234,8 +246,10 @@ exports[`objects > crossSerializeAsync > scoped > supports Symbol.iterator 1`] =
 "($R=>$R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -279,45 +293,49 @@ exports[`objects > crossSerializeAsync > supports Symbol.asyncIterator 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -360,58 +378,62 @@ exports[`objects > crossSerializeAsync > supports Symbol.asyncIterator 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -425,8 +447,10 @@ exports[`objects > crossSerializeAsync > supports Symbol.iterator 1`] = `
 "$R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -491,45 +515,49 @@ exports[`objects > crossSerializeStream > scoped > supports Symbol.asyncIterator
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -572,58 +600,62 @@ exports[`objects > crossSerializeStream > scoped > supports Symbol.asyncIterator
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -664,8 +696,10 @@ exports[`objects > crossSerializeStream > scoped > supports Symbol.iterator 2`] 
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -753,45 +787,49 @@ exports[`objects > crossSerializeStream > supports Symbol.asyncIterator 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -834,58 +872,62 @@ exports[`objects > crossSerializeStream > supports Symbol.asyncIterator 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -926,8 +968,10 @@ exports[`objects > crossSerializeStream > supports Symbol.iterator 2`] = `
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -980,8 +1024,10 @@ exports[`objects > serialize > supports Symbol.iterator 1`] = `
 "(h=>({[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -1025,45 +1071,49 @@ exports[`objects > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -1106,58 +1156,62 @@ exports[`objects > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -1171,8 +1225,10 @@ exports[`objects > serializeAsync > supports Symbol.iterator 1`] = `
 "(h=>Promise.resolve({[h=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,

--- a/packages/seroval/test/__snapshots__/sealed-object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/sealed-object.test.ts.snap
@@ -6,8 +6,10 @@ exports[`sealed object > crossSerialize > scoped > supports Symbol.iterator 1`] 
 "($R=>($R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -37,8 +39,10 @@ exports[`sealed object > crossSerialize > supports Symbol.iterator 1`] = `
 "($R[0]={[$R[1]=Symbol.iterator]:($R[2]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -82,45 +86,49 @@ exports[`sealed object > crossSerializeAsync > scoped > supports Symbol.asyncIte
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -163,58 +171,62 @@ exports[`sealed object > crossSerializeAsync > scoped > supports Symbol.asyncIte
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -228,8 +240,10 @@ exports[`sealed object > crossSerializeAsync > scoped > supports Symbol.iterator
 "($R=>($R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -273,45 +287,49 @@ exports[`sealed object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -354,58 +372,62 @@ exports[`sealed object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -419,8 +441,10 @@ exports[`sealed object > crossSerializeAsync > supports Symbol.iterator 1`] = `
 "($R[0]=Promise.resolve($R[1]={[$R[2]=Symbol.iterator]:($R[3]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -485,45 +509,49 @@ exports[`sealed object > crossSerializeStream > scoped > supports Symbol.asyncIt
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -566,58 +594,62 @@ exports[`sealed object > crossSerializeStream > scoped > supports Symbol.asyncIt
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -658,8 +690,10 @@ exports[`sealed object > crossSerializeStream > scoped > supports Symbol.iterato
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -747,45 +781,49 @@ exports[`sealed object > crossSerializeStream > supports Symbol.asyncIterator 1`
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -828,58 +866,62 @@ exports[`sealed object > crossSerializeStream > supports Symbol.asyncIterator 1`
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -920,8 +962,10 @@ exports[`sealed object > crossSerializeStream > supports Symbol.iterator 2`] = `
 })($R[1],$R[3]={[$R[4]=Symbol.iterator]:($R[5]=((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -974,8 +1018,10 @@ exports[`sealed object > serialize > supports Symbol.iterator 1`] = `
 "((h,j)=>(h={[j=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,
@@ -1019,45 +1065,49 @@ exports[`sealed object > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let isThrow = false;
   const buffer = [];
   const pending = [];
-  const finalize = (i = 0, len = pending.length) => {
-    for (; i < len; i++) {
-      pending[i].s({
-        done: true,
-        value: void 0
-      });
+  const internal = {
+    finalize(i = 0, len = pending.length) {
+      for (; i < len; i++) {
+        pending[i].s({
+          done: true,
+          value: void 0
+        });
+      }
     }
   };
   stream.on({
-    next: (value) => {
+    next(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: false, value });
       };
       buffer.push(value);
     },
-    throw: (value) => {
+    throw(value) {
       const temp = pending.shift();
       if (temp) {
         temp.f(value);
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       isThrow = true;
       buffer.push(value);
     },
-    return: (value) => {
+    return(value) {
       const temp = pending.shift();
       if (temp) {
         temp.s({ done: true, value });
       };
-      finalize();
+      internal.finalize();
       doneAt = buffer.length;
       buffer.push(value);
     }
   });
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (doneAt === -1) {
         const index2 = count++;
         if (index2 >= buffer.length) {
@@ -1100,58 +1150,62 @@ exports[`sealed object > serializeAsync > supports Symbol.asyncIterator 1`] = `
   let alive = true;
   let success = false;
   let count = 0;
-  const flush = (value, mode, x) => {
-    for (x = 0; x < count; x++) {
-      if (listeners[x]) {
-        listeners[x][mode](value);
+  const internal = {
+    flush(value, mode, x) {
+      for (x = 0; x < count; x++) {
+        if (listeners[x]) {
+          listeners[x][mode](value);
+        }
       }
-    }
-  };
-  const up = (listener, x, z, current) => {
-    for (x = 0, z = buffer.length; x < z; x++) {
-      current = buffer[x];
-      if (!alive && x === z - 1) {
-        listener[success ? "return" : "throw"](current);
-      } else {
-        listener.next(current);
+    },
+    up(listener, x, z, current) {
+      for (x = 0, z = buffer.length; x < z; x++) {
+        current = buffer[x];
+        if (!alive && x === z - 1) {
+          listener[success ? "return" : "throw"](current);
+        } else {
+          listener.next(current);
+        }
       }
-    }
-  };
-  const on = (listener, temp) => {
-    if (alive) {
-      temp = count++;
-      listeners[temp] = listener;
-    };
-    up(listener);
-    return () => {
+    },
+    on(listener, temp) {
       if (alive) {
-        listeners[temp] = listeners[count];
-        listeners[count--] = void 0;
-      }
-    };
+        temp = count++;
+        listeners[temp] = listener;
+      };
+      internal.up(listener);
+      return () => {
+        if (alive) {
+          listeners[temp] = listeners[count];
+          listeners[count--] = void 0;
+        }
+      };
+    }
   };
   return {
     __SEROVAL_STREAM__: true,
-    on: (listener) => on(listener),
-    next: (value) => {
+    on(listener) {
+      return internal.on(listener);
+    },
+    next(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "next");
+        internal.flush(value, "next");
       }
     },
-    throw: (value) => {
+    throw(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "throw");
+        internal.flush(value, "throw");
         alive = false;
         success = false;
         listeners.length = 0;
       }
     },
-    return: (value) => {
+    return(value) {
       if (alive) {
         buffer.push(value);
-        flush(value, "return");
+        internal.flush(value, "return");
         alive = false;
         success = true;
         listeners.length = 0;
@@ -1165,8 +1219,10 @@ exports[`sealed object > serializeAsync > supports Symbol.iterator 1`] = `
 "((h,j,k)=>(k=Promise.resolve(h={[j=Symbol.iterator]:(((symbol) => (sequence) => () => {
   let index = 0;
   const instance = {
-    [symbol]: () => instance,
-    next: () => {
+    [symbol]() {
+      return instance;
+    },
+    next() {
       if (index > sequence.d) {
         return {
           done: true,

--- a/packages/seroval/test/keep-names.test.ts
+++ b/packages/seroval/test/keep-names.test.ts
@@ -1,0 +1,136 @@
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/lxsmnsyc/seroval/issues/87
+//
+// Serialized constructors are derived from Function.prototype.toString() of
+// functions in the running bundle. If the library was bundled with a
+// name-preserving transform (esbuild --keep-names, applied by some platforms
+// downstream of the app's own build), nested functions get rewritten to call
+// a bundle-scoped helper, and payloads evaluated in a realm that never loaded
+// that bundle throw ReferenceError.
+//
+// This suite bundles the library the way such a platform would
+// (keepNames + minify — minify also renames the helper itself, so no global
+// shim can compensate), generates payloads from inside that bundle, then
+// evaluates AND consumes them in a scope that only sees globals. Consuming is
+// the important part: helper calls hide inside function bodies, so a payload
+// can evaluate cleanly and still be broken.
+
+const FIXTURE = `
+import { crossSerializeStream, serialize, serializeAsync } from './src';
+
+const ASYNC_ITERABLE = {
+  async *[Symbol.asyncIterator]() {
+    yield 'foo';
+    yield 'bar';
+  },
+};
+
+function collectStream(value: unknown): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const chunks: string[] = [];
+    crossSerializeStream(value, {
+      onSerialize(data) {
+        chunks.push(data);
+      },
+      onDone() {
+        resolve(chunks);
+      },
+      onError(error) {
+        reject(error);
+      },
+    });
+  });
+}
+
+export async function getPayloads() {
+  return {
+    iterable: serialize({
+      *[Symbol.iterator]() {
+        yield 1;
+        yield 2;
+        yield 3;
+      },
+    }),
+    asyncIterable: await serializeAsync(ASYNC_ITERABLE),
+    promise: await serializeAsync(Promise.resolve('resolved')),
+    streamChunks: await collectStream(ASYNC_ITERABLE),
+  };
+}
+`;
+
+interface Payloads {
+  iterable: string;
+  asyncIterable: string;
+  promise: string;
+  streamChunks: string[];
+}
+
+let cached: Promise<Payloads> | undefined;
+
+function getBundledPayloads(): Promise<Payloads> {
+  cached ||= bundleAndRun();
+  return cached;
+}
+
+async function bundleAndRun(): Promise<Payloads> {
+  const result = await build({
+    stdin: {
+      contents: FIXTURE,
+      resolveDir: fileURLToPath(new URL('..', import.meta.url)),
+      loader: 'ts',
+    },
+    bundle: true,
+    keepNames: true,
+    minify: true,
+    format: 'esm',
+    platform: 'node',
+    write: false,
+  });
+  const code = result.outputFiles[0].text;
+  const mod = await import(
+    `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
+  );
+  return mod.getPayloads();
+}
+
+// Function bodies only see globals — same visibility as a payload evaluated
+// in a browser that never loaded the server bundle.
+function evaluate<T>(payload: string): T {
+  return new Function(`return (${payload})`)() as T;
+}
+
+async function drain<T>(value: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of value) {
+    items.push(item);
+  }
+  return items;
+}
+
+describe('keep-names bundled payloads', () => {
+  it('supports Iterables', async () => {
+    const payloads = await getBundledPayloads();
+    const back = evaluate<Iterable<number>>(payloads.iterable);
+    expect([...back]).toEqual([1, 2, 3]);
+  });
+  it('supports AsyncIterables', async () => {
+    const payloads = await getBundledPayloads();
+    const back = evaluate<AsyncIterable<string>>(payloads.asyncIterable);
+    expect(await drain(back)).toEqual(['foo', 'bar']);
+  });
+  it('supports Promises', async () => {
+    const payloads = await getBundledPayloads();
+    const back = evaluate<Promise<string>>(payloads.promise);
+    await expect(back).resolves.toBe('resolved');
+  });
+  it('supports crossSerializeStream', async () => {
+    const payloads = await getBundledPayloads();
+    const $R: unknown[] = [];
+    new Function('$R', payloads.streamChunks.join(';\n'))($R);
+    const back = $R[0] as AsyncIterable<string>;
+    expect(await drain(back)).toEqual(['foo', 'bar']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.6
         version: 4.0.6(vitest@4.0.6)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       seroval:
         specifier: 1.5.5
         version: 1.5.5
@@ -102,6 +105,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.6
         version: 4.0.6(vitest@4.0.6)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
@@ -176,28 +182,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.2':
     resolution: {integrity: sha512-amnqvk+gWybbQleRRq8TMe0rIv7GHss8mFJEaGuEZYWg1Tw14YKOkeo8h6pf1c+d3qR+JU4iT9KXnBKGON4klw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.2':
     resolution: {integrity: sha512-gzB19MpRdTuOuLtPpFBGrV3Lq424gHyq2lFj8wfX9tvLMLdmA/R9C7k/mqBp/spcbWuHeIEKgEs3RviOPcWGBA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.2':
     resolution: {integrity: sha512-8BG/vRAhFz1pmuyd24FQPhNeueLqPtwvZk6yblABY2gzL2H8fLQAF/Z2OPIc+BPIVPld+8cSiKY/KFh6k81xfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.2':
     resolution: {integrity: sha512-lCruqQlfWjhMlOdyf5pDHOxoNm4WoyY2vZ4YN33/nuZBRstVDuqPPjS0yBkbUlLEte11FbpW+wWSlfnZfSIZvg==}
@@ -287,8 +289,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.1':
     resolution: {integrity: sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -299,8 +313,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.1':
     resolution: {integrity: sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -311,8 +337,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.1':
     resolution: {integrity: sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -323,8 +361,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.1':
     resolution: {integrity: sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -335,8 +385,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.1':
     resolution: {integrity: sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -347,8 +409,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.1':
     resolution: {integrity: sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -359,8 +433,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.1':
     resolution: {integrity: sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -371,8 +457,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.1':
     resolution: {integrity: sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -383,8 +481,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.1':
     resolution: {integrity: sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -395,8 +505,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.1':
     resolution: {integrity: sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -407,8 +529,26 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.25.1':
     resolution: {integrity: sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -419,14 +559,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.1':
     resolution: {integrity: sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.1':
     resolution: {integrity: sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -511,42 +669,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.0':
     resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.0':
     resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
@@ -608,67 +760,56 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -898,37 +1039,31 @@ packages:
     resolution: {integrity: sha512-CAjbJexBJUqHgIPgOCJO7EYRnFluNLt5VD3jNS40wmsNZqa04HbewVVcgfmzfzuBhjX6ookntLDG3lWieyTAVw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-musl@0.7.4':
     resolution: {integrity: sha512-HQMuKBltnKFUqhUh8wNiivd76coRwDngdCxbcAULlatAlc2OXo8L6jLTkVnNeUuOw9JYzSq9LY2/7zvrg63Ddg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.7.4':
     resolution: {integrity: sha512-cnU7ZVxK/Oq/TIS2iq56rouy1dqnLYgWR2puWcrxGCtmbdxiMISANYhI5t2tMLzTGZMyhawM2zYlyI+gnpBupQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-musl@0.7.4':
     resolution: {integrity: sha512-NyuabTumcxPtZv/Q+pMVvrcKxLn1SPcpdBGtekVJz7JwI36SuExTq4IG4EZsk7YDmFKP8wDEvmKYOpV/a8Lwhw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.7.4':
     resolution: {integrity: sha512-w3EnCLPD2vpJw0F+0qVV/1KSOAw4SgzjbGUbbwXUh9w5Kxo1Hdc3mN+/Nvk50oA6cCbSOCEaILnPHXPCauArvg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-musl@0.7.4':
     resolution: {integrity: sha512-FXKQlFjDM8FxqJ/TncAni7e7JyaXIB3Hv6boApxSs5ZUlvqP4TbrjYVk3mYDQt6xQAE/kEHplxM6m5SKx5sfRg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-win32-arm64@0.7.4':
     resolution: {integrity: sha512-rWr899KEvZIWMx9yUXQl4i90OGIs4gaw4X1UsS2rxsI3qnp8acLIVKI3N5WDqaertkW10crDRZvIxxyw7kTMTQ==}
@@ -959,37 +1094,31 @@ packages:
     resolution: {integrity: sha512-j3s3LJxEbOyP58hmzuXpJlKzgxaswuOTu8nAbDpE119b5W3gP1SW+HndLscGUOACpyMdH5WJ6gBHRxq0HCRVBw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-musl@0.7.4':
     resolution: {integrity: sha512-PUpHPmvWIDxhYTS5oah08RQ28t6dlFBxRPJcftS6HgquiPsm/e0gL5vKwPJpyjaPBHzRH61IAUDDfrRe8iFs8g==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.7.4':
     resolution: {integrity: sha512-Hi3w0et5mu3i7S+qE0UgOev4RqJ/U9DW8xn79t4nttiICYCx3NveC0Goo78uqzxttsDI3hfRY43lrrF26svqcw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-musl@0.7.4':
     resolution: {integrity: sha512-i073u4ENL9DJeWBRKioRCz8i5hg6EmUcH89eH1lts9f9AFPA1GphODwK6OXOXUbpi2AwZ1deFIUWgLGP2mdmmA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-x64-gnu@0.7.4':
     resolution: {integrity: sha512-j5pt0LyDGxCzfoqRTR3cmMG21+bgSxIufAzJXFOWXkbg/22Ih51eGEsbInnSD5Q9FvJ3ooIn/jfok0dBdhudnA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-musl@0.7.4':
     resolution: {integrity: sha512-RR1hNhrSpv3FanLM6u5uD+9CYA9IM8U3uGscgvKKV77gtj7ttO4UubpwN7vcx1KknoEIQHKJFPVKoeVy+avf6w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-win32-arm64@0.7.4':
     resolution: {integrity: sha512-1xhYwOLo9TjppHHwNYi3X/dGgOvnj9xh62jpgP4U8nEtTGA70NtJDCkN45pRQdU3B6/U7oQj1T4esP3aFJg6BA==}
@@ -1185,6 +1314,11 @@ packages:
 
   esbuild@0.25.1:
     resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1443,6 +1577,7 @@ packages:
   next-json@0.4.0:
     resolution: {integrity: sha512-AwnKfYVazg1D9eHkyzeyHFIrtrIwjL2Rwnj49EBzVvjHA/d7RgsQ0FGnLbnIM26NfJ79SfQg4n7iQNKEtXNbAg==}
     engines: {node: '>=14.0'}
+    deprecated: Please see https://github.com/iccicci/next-json#version-050
 
   o-son@1.0.4:
     resolution: {integrity: sha512-tdGKxZgiTexSv97/igC2m8Y6FljgwvwHW/Zy3ql3Jx6MPKrPKaBDLhV7rz8uuLjcDPw6Pxa2PVsnWwen59MmnQ==}
@@ -2165,76 +2300,154 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.25.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.25.1':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.25.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.25.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.25.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.25.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.1':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.25.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@inquirer/external-editor@1.0.2(@types/node@24.10.0)':
@@ -2797,6 +3010,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.1
       '@esbuild/win32-ia32': 0.25.1
       '@esbuild/win32-x64': 0.25.1
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-string-regexp@1.0.5: {}
 


### PR DESCRIPTION
Fixes #87 — covers every serialized constructor, per the thread.

**Fix:** all nested functions inside `toString()`-serialized constructors are now object methods in shorthand form (local closures hoisted onto internal object literals). A shorthand method's name comes from its property key (`NamedEvaluation`), so keep-names transforms emit nothing for it — every other shape gets wrapped in a bundle-scoped `__name` helper that doesn't exist in the receiving realm.

**Tests:** `keep-names.test.ts` in both packages — bundle the library with esbuild `keepNames` + `minify`, then evaluate **and consume** every payload with only globals in scope (consuming matters: the helper calls hide inside function bodies). Iterable, async iterable, cross-stream, and `ReadableStream` payloads all fail before this change and pass after; the already-immune constructors (promise, `FormData`, `AbortSignal`) are locked in too.

**Diff note:** the real change is ~360 lines. The rest is `vitest -u` snapshot regeneration — constructor text is embedded in the baselines — now marked `linguist-generated` so review collapses it. The plugins test aliases `seroval` to the workspace build because the `1.5.5` devDependency pin resolves to the registry and can't see core fixes (worth a `workspace:*` follow-up).

_Supersedes #88 — GitHub would not reopen it after a force-push._
