### PR TITLE
perf: accelerate escaping of long strings

### DIFF
--- a/.changeset/fast-long-strings.md
+++ b/.changeset/fast-long-strings.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Reduce the cost of escaping long strings while preserving their serialized representation.

--- a/packages/seroval/src/core/string.ts
+++ b/packages/seroval/src/core/string.ts
@@ -1,5 +1,10 @@
 import { NIL } from './constants';
 
+// JSON escapes these code units differently from Seroval's wire format.
+const JSON_ESCAPE_DIFFERENCES =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Match the control characters that require the existing encoder.
+  /[\x00-\x07\x0b\x0e-\x1f<\u2028\u2029\ud800-\udfff]/;
+
 export function serializeChar(str: string): string | undefined {
   switch (str) {
     case '"':
@@ -33,6 +38,9 @@ export function serializeChar(str: string): string | undefined {
 // Also includes "<" to escape "</script>" and "\" to avoid invalid escapes in the output.
 // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
 export function serializeString(str: string): string {
+  if (str.length >= 1024 && !JSON_ESCAPE_DIFFERENCES.test(str)) {
+    return JSON.stringify(str).slice(1, -1);
+  }
   let result = '';
   let lastPos = 0;
   let replacement: string | undefined;

--- a/packages/seroval/src/core/string.ts
+++ b/packages/seroval/src/core/string.ts
@@ -1,5 +1,7 @@
 import { NIL } from './constants';
 
+const MIN_JSON_STRINGIFY_LENGTH = 64;
+
 // JSON escapes these code units differently from Seroval's wire format.
 const JSON_ESCAPE_DIFFERENCES =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: Match the control characters that require the existing encoder.
@@ -38,7 +40,10 @@ export function serializeChar(str: string): string | undefined {
 // Also includes "<" to escape "</script>" and "\" to avoid invalid escapes in the output.
 // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
 export function serializeString(str: string): string {
-  if (str.length >= 1024 && !JSON_ESCAPE_DIFFERENCES.test(str)) {
+  if (
+    str.length >= MIN_JSON_STRINGIFY_LENGTH &&
+    !JSON_ESCAPE_DIFFERENCES.test(str)
+  ) {
     return JSON.stringify(str).slice(1, -1);
   }
   let result = '';

--- a/packages/seroval/test/long-string.test.ts
+++ b/packages/seroval/test/long-string.test.ts
@@ -25,9 +25,12 @@ const escapes: Record<string, string> = {
   '\u2029': '\\u2029',
 };
 const cases = [
-  ['below threshold', 'x'.repeat(1023)],
-  ['at threshold', 'x'.repeat(1024)],
-  ['above threshold', 'x'.repeat(1025)],
+  ['below threshold', 'x'.repeat(63)],
+  ['at threshold', 'x'.repeat(64)],
+  ['above threshold', 'x'.repeat(65)],
+  ['below threshold with escape', 'x'.repeat(62) + '"'],
+  ['at threshold with escape', 'x'.repeat(63) + '"'],
+  ['above threshold with escape', 'x'.repeat(64) + '"'],
   [
     'JSON text',
     JSON.stringify({ items: new Array(100).fill({ text: 'a"b\\c\n' }) }),
@@ -60,7 +63,7 @@ describe('long strings', () => {
   );
 
   it('preserves every UTF-16 code unit inside long strings', () => {
-    const padding = 'x'.repeat(1024);
+    const padding = 'x'.repeat(63);
     for (let code = 0; code <= 0xffff; code++) {
       const char = String.fromCharCode(code);
       expect(serializeString(padding + char)).toBe(

--- a/packages/seroval/test/long-string.test.ts
+++ b/packages/seroval/test/long-string.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  crossSerializeStream,
+  deserialize,
+  fromCrossJSON,
+  fromJSON,
+  serialize,
+  serializeAsync,
+  toCrossJSON,
+  toCrossJSONStream,
+  toJSON,
+} from '../src';
+import { serializeString } from '../src/core/string';
+
+const escapes: Record<string, string> = {
+  '"': '\\"',
+  '\\': '\\\\',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\b': '\\b',
+  '\t': '\\t',
+  '\f': '\\f',
+  '<': '\\x3C',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+const cases = [
+  ['below threshold', 'x'.repeat(1023)],
+  ['at threshold', 'x'.repeat(1024)],
+  ['above threshold', 'x'.repeat(1025)],
+  [
+    'JSON text',
+    JSON.stringify({ items: new Array(100).fill({ text: 'a"b\\c\n' }) }),
+  ],
+  ['HTML and separators', '</script><!--\u2028\u2029'.repeat(128)],
+  ['Latin-1 and BMP', 'caf\u00e9 \u4e2d\u6587'.repeat(256)],
+  ['surrogate pairs', '\ud83d\ude00'.repeat(1024)],
+  ['lone high surrogate', 'x'.repeat(1024) + '\ud800'],
+  ['lone low surrogate', '\udfff' + 'x'.repeat(1024)],
+  ['control characters', 'x'.repeat(1024) + '\x00\x01\x07\x0b\x0e\x1f'],
+  ['literal escapes', '\\u0000\\ud800\\x3C'.repeat(128)],
+] as const;
+
+describe('long strings', () => {
+  it.each(cases)(
+    'preserves encoding and round-trips %s',
+    async (_name, value) => {
+      const expected = Array.from(value, char => escapes[char] ?? char).join(
+        '',
+      );
+      expect(serializeString(value)).toBe(expected);
+      expect(serialize(value)).toBe(`"${expected}"`);
+      expect(deserialize(serialize(value))).toBe(value);
+      expect(await serializeAsync(value)).toBe(`"${expected}"`);
+      expect(fromJSON(toJSON(value))).toBe(value);
+      expect(fromCrossJSON(toCrossJSON(value), { refs: new Map() })).toBe(
+        value,
+      );
+    },
+  );
+
+  it('preserves every UTF-16 code unit inside long strings', () => {
+    const padding = 'x'.repeat(1024);
+    for (let code = 0; code <= 0xffff; code++) {
+      const char = String.fromCharCode(code);
+      expect(serializeString(padding + char)).toBe(
+        padding + (escapes[char] ?? char),
+      );
+    }
+  });
+
+  it('escapes a long deferred SSR value', async () => {
+    const value = '</script><!--"\\\n\u2028\u2029'.repeat(128);
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      crossSerializeStream(Promise.resolve(value), {
+        onSerialize(chunk) {
+          expect(chunk).not.toContain('</script');
+          chunks.push(chunk);
+        },
+        onDone: resolve,
+        onError: reject,
+      });
+    });
+    expect(chunks.join('')).toContain(serializeString(value));
+  });
+
+  it('round-trips long deferred server-function data', async () => {
+    const value = JSON.stringify({
+      items: new Array(100).fill('"\\\n'),
+    });
+    const refs = new Map();
+    let restored: Promise<string> | undefined;
+    await new Promise<void>((resolve, reject) => {
+      toCrossJSONStream(Promise.resolve(value), {
+        onParse(node, initial) {
+          const result = fromCrossJSON<Promise<string>>(node, { refs });
+          if (initial) {
+            restored = result;
+          }
+        },
+        onDone: resolve,
+        onError: reject,
+      });
+    });
+    expect(await restored).toBe(value);
+  });
+});

--- a/packages/seroval/test/string.bench.ts
+++ b/packages/seroval/test/string.bench.ts
@@ -1,0 +1,25 @@
+import { bench, describe } from 'vitest';
+import { serialize, toJSON } from '../src';
+
+const record = JSON.stringify({ id: 1, text: 'a"b\\c\n', active: true });
+const cases = [
+  ['short key', 'queryHash'],
+  ['short escaped value', 'a"b\\c\n'],
+  ['1 KiB plain text', 'x'.repeat(1024)],
+  ['1 KiB JSON text', record.repeat(32).slice(0, 1024)],
+  ['64 KiB JSON text', record.repeat(2048).slice(0, 65536)],
+  ['1 MiB JSON text', record.repeat(32768).slice(0, 1048576)],
+  ['HTML text', '<p>Text</p>\u2028'.repeat(8192)],
+  ['surrogate fallback', '\ud83d\ude00'.repeat(32768)],
+] as const;
+
+for (const [name, value] of cases) {
+  describe(name, () => {
+    bench('serialize', () => {
+      serialize(value);
+    });
+    bench('toJSON', () => {
+      toJSON(value);
+    });
+  });
+}

--- a/packages/seroval/test/string.bench.ts
+++ b/packages/seroval/test/string.bench.ts
@@ -5,6 +5,10 @@ const record = JSON.stringify({ id: 1, text: 'a"b\\c\n', active: true });
 const cases = [
   ['short key', 'queryHash'],
   ['short escaped value', 'a"b\\c\n'],
+  ['64 code units plain text', 'x'.repeat(64)],
+  ['64 code units JSON text', record.repeat(2).slice(0, 64)],
+  ['64 code units HTML fallback', 'x'.repeat(55) + '</script>'],
+  ['64 code units surrogate fallback', 'x'.repeat(62) + '\ud83d\ude00'],
   ['1 KiB plain text', 'x'.repeat(1024)],
   ['1 KiB JSON text', record.repeat(32).slice(0, 1024)],
   ['64 KiB JSON text', record.repeat(2048).slice(0, 65536)],


### PR DESCRIPTION
Use native JSON string escaping for strings of at least 64 code units when it produces the same representation as the existing encoder. This reduces serialization work for large text values, including JSON strings.

The threshold is 64 code units because local Node 24 comparisons showed gains for eligible plain text, JSON text, and BMP Unicode at that length. A threshold of 32 slightly slowed the BMP Unicode case, while 128 and 256 left gains on shorter strings unused. Strings below 64 code units skip the compatibility scan. This is a workload-dependent compromise: strings that require the existing encoder pay for an extra scan once they reach the threshold.

On Node 24, serializing a 1 MiB JSON string dropped from 10.1 ms to 3.9 ms (62% less time). A JSON string from the roughly 0.9 MB catalog fixture dropped from 3.12 ms to 2.60 ms (17% less). These measure serialization, not full request latency.

Strings containing HTML-sensitive characters, line separators, surrogates, or control characters with different JSON escaping retain the existing encoder. The serialized format and public API are unchanged.
