### PR TITLE
fix: preserve active stream listeners during cleanup

### DIFF
--- a/.changeset/stream-listener-cleanup.md
+++ b/.changeset/stream-listener-cleanup.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Keep stream listeners active when another subscription is removed, and make subscription cleanup idempotent.

--- a/packages/plugins/tests/web/__snapshots__/readable-stream.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/readable-stream.test.ts.snap
@@ -25,7 +25,10 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -34,16 +37,20 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -106,7 +113,10 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -115,16 +125,20 @@ exports[`ReadableStream > crossSerializeAsync > scoped > supports ReadableStream
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -187,7 +201,10 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -196,16 +213,20 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -268,7 +289,10 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream errors 1
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -277,16 +301,20 @@ exports[`ReadableStream > crossSerializeAsync > supports ReadableStream errors 1
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -349,7 +377,10 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -358,16 +389,20 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -438,7 +473,10 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -447,16 +485,20 @@ exports[`ReadableStream > crossSerializeStream > scoped > supports ReadableStrea
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -521,7 +563,10 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -530,16 +575,20 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -610,7 +659,10 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream errors 
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -619,16 +671,20 @@ exports[`ReadableStream > crossSerializeStream > supports ReadableStream errors 
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -693,7 +749,10 @@ exports[`ReadableStream > serializeAsync > supports ReadableStream 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -702,16 +761,20 @@ exports[`ReadableStream > serializeAsync > supports ReadableStream 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -774,7 +837,10 @@ exports[`ReadableStream > serializeAsync > supports ReadableStream errors 1`] = 
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -783,16 +849,20 @@ exports[`ReadableStream > serializeAsync > supports ReadableStream errors 1`] = 
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/plugins/tests/web/__snapshots__/request.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/request.test.ts.snap
@@ -55,7 +55,10 @@ exports[`Request > crossSerializeStream > scoped > supports Request 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -64,16 +67,20 @@ exports[`Request > crossSerializeStream > scoped > supports Request 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -148,7 +155,10 @@ exports[`Request > crossSerializeStream > supports Request 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -157,16 +167,20 @@ exports[`Request > crossSerializeStream > supports Request 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/plugins/tests/web/__snapshots__/response.test.ts.snap
+++ b/packages/plugins/tests/web/__snapshots__/response.test.ts.snap
@@ -45,7 +45,10 @@ exports[`Response > crossSerializeStream > scoped > supports Response 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -54,16 +57,20 @@ exports[`Response > crossSerializeStream > scoped > supports Response 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}
@@ -138,7 +145,10 @@ exports[`Response > crossSerializeStream > supports Response 1`] = `
 	let count = 0;
 	const internal = {
 		flush(value, mode, x) {
-			for (x = 0; x < count; x++) if (listeners[x]) listeners[x][mode](value);
+			for (x = 0; x < count; x++) {
+				const listener = listeners[x];
+				if (listener) listener[mode](value);
+			}
 		},
 		up(listener, x, z, current) {
 			for (x = 0, z = buffer.length; x < z; x++) {
@@ -147,16 +157,20 @@ exports[`Response > crossSerializeStream > supports Response 1`] = `
 				else listener.next(current);
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) if (!listeners[temp]) break;
+				if (temp === count) count++;
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = void 0;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = void 0;
+					while (count > 0 && !listeners[count - 1]) count--;
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/src/core/constructors.ts
+++ b/packages/seroval/src/core/constructors.ts
@@ -61,15 +61,16 @@ interface StreamListener<T> {
 // receiving realm. https://github.com/lxsmnsyc/seroval/issues/87
 export const STREAM_CONSTRUCTOR = () => {
   const buffer: unknown[] = [];
-  const listeners: StreamListener<unknown>[] = [];
+  const listeners: (StreamListener<unknown> | undefined)[] = [];
   let alive = true;
   let success = false;
   let count = 0;
   const internal = {
     flush(value: unknown, mode: keyof StreamListener<unknown>, x?: number) {
       for (x = 0; x < count; x++) {
-        if (listeners[x]) {
-          listeners[x][mode](value);
+        const listener = listeners[x];
+        if (listener) {
+          listener[mode](value);
         }
       }
     },
@@ -88,16 +89,28 @@ export const STREAM_CONSTRUCTOR = () => {
         }
       }
     },
-    on(listener: StreamListener<unknown>, temp?: number) {
+    on(listener: StreamListener<unknown>, temp = 0) {
+      let subscribed = alive;
       if (alive) {
-        temp = count++;
+        for (temp = 0; temp < count; temp++) {
+          if (!listeners[temp]) {
+            break;
+          }
+        }
+        if (temp === count) {
+          count++;
+        }
         listeners[temp] = listener;
       }
       internal.up(listener);
       return () => {
-        if (alive) {
-          listeners[temp!] = listeners[count];
-          listeners[count--] = undefined as any;
+        if (alive && subscribed) {
+          subscribed = false;
+          listeners[temp] = undefined;
+          while (count > 0 && !listeners[count - 1]) {
+            count--;
+          }
+          listeners.length = count;
         }
       };
     },

--- a/packages/seroval/test/__snapshots__/async-iterable.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/async-iterable.test.ts.snap
@@ -110,8 +110,9 @@ exports[`AsyncIterable > crossSerializeAsync > scoped > supports AsyncIterables 
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -125,16 +126,28 @@ exports[`AsyncIterable > crossSerializeAsync > scoped > supports AsyncIterables 
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -282,8 +295,9 @@ exports[`AsyncIterable > crossSerializeAsync > supports AsyncIterables 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -297,16 +311,28 @@ exports[`AsyncIterable > crossSerializeAsync > supports AsyncIterables 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -454,8 +480,9 @@ exports[`AsyncIterable > crossSerializeStream > scoped > supports AsyncIterables
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -469,16 +496,28 @@ exports[`AsyncIterable > crossSerializeStream > scoped > supports AsyncIterables
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -634,8 +673,9 @@ exports[`AsyncIterable > crossSerializeStream > supports AsyncIterables 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -649,16 +689,28 @@ exports[`AsyncIterable > crossSerializeStream > supports AsyncIterables 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -814,8 +866,9 @@ exports[`AsyncIterable > serializeAsync > supports AsyncIterables 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -829,16 +882,28 @@ exports[`AsyncIterable > serializeAsync > supports AsyncIterables 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/test/__snapshots__/frozen-object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/frozen-object.test.ts.snap
@@ -178,8 +178,9 @@ exports[`frozen object > crossSerializeAsync > scoped > supports Symbol.asyncIte
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -193,16 +194,28 @@ exports[`frozen object > crossSerializeAsync > scoped > supports Symbol.asyncIte
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -383,8 +396,9 @@ exports[`frozen object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -398,16 +412,28 @@ exports[`frozen object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -609,8 +635,9 @@ exports[`frozen object > crossSerializeStream > scoped > supports Symbol.asyncIt
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -624,16 +651,28 @@ exports[`frozen object > crossSerializeStream > scoped > supports Symbol.asyncIt
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -885,8 +924,9 @@ exports[`frozen object > crossSerializeStream > supports Symbol.asyncIterator 1`
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -900,16 +940,28 @@ exports[`frozen object > crossSerializeStream > supports Symbol.asyncIterator 1`
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -1173,8 +1225,9 @@ exports[`frozen object > serializeAsync > supports Symbol.asyncIterator 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -1188,16 +1241,28 @@ exports[`frozen object > serializeAsync > supports Symbol.asyncIterator 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/test/__snapshots__/null-constructor.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/null-constructor.test.ts.snap
@@ -184,8 +184,9 @@ exports[`null-constructor > crossSerializeAsync > scoped > supports Symbol.async
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -199,16 +200,28 @@ exports[`null-constructor > crossSerializeAsync > scoped > supports Symbol.async
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -389,8 +402,9 @@ exports[`null-constructor > crossSerializeAsync > supports Symbol.asyncIterator 
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -404,16 +418,28 @@ exports[`null-constructor > crossSerializeAsync > supports Symbol.asyncIterator 
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -615,8 +641,9 @@ exports[`null-constructor > crossSerializeStream > scoped > supports Symbol.asyn
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -630,16 +657,28 @@ exports[`null-constructor > crossSerializeStream > scoped > supports Symbol.asyn
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -891,8 +930,9 @@ exports[`null-constructor > crossSerializeStream > supports Symbol.asyncIterator
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -906,16 +946,28 @@ exports[`null-constructor > crossSerializeStream > supports Symbol.asyncIterator
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -1179,8 +1231,9 @@ exports[`null-constructor > serializeAsync > supports Symbol.asyncIterator 1`] =
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -1194,16 +1247,28 @@ exports[`null-constructor > serializeAsync > supports Symbol.asyncIterator 1`] =
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/test/__snapshots__/object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/object.test.ts.snap
@@ -184,8 +184,9 @@ exports[`objects > crossSerializeAsync > scoped > supports Symbol.asyncIterator 
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -199,16 +200,28 @@ exports[`objects > crossSerializeAsync > scoped > supports Symbol.asyncIterator 
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -389,8 +402,9 @@ exports[`objects > crossSerializeAsync > supports Symbol.asyncIterator 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -404,16 +418,28 @@ exports[`objects > crossSerializeAsync > supports Symbol.asyncIterator 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -615,8 +641,9 @@ exports[`objects > crossSerializeStream > scoped > supports Symbol.asyncIterator
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -630,16 +657,28 @@ exports[`objects > crossSerializeStream > scoped > supports Symbol.asyncIterator
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -891,8 +930,9 @@ exports[`objects > crossSerializeStream > supports Symbol.asyncIterator 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -906,16 +946,28 @@ exports[`objects > crossSerializeStream > supports Symbol.asyncIterator 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -1179,8 +1231,9 @@ exports[`objects > serializeAsync > supports Symbol.asyncIterator 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -1194,16 +1247,28 @@ exports[`objects > serializeAsync > supports Symbol.asyncIterator 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/test/__snapshots__/sealed-object.test.ts.snap
+++ b/packages/seroval/test/__snapshots__/sealed-object.test.ts.snap
@@ -178,8 +178,9 @@ exports[`sealed object > crossSerializeAsync > scoped > supports Symbol.asyncIte
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -193,16 +194,28 @@ exports[`sealed object > crossSerializeAsync > scoped > supports Symbol.asyncIte
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -383,8 +396,9 @@ exports[`sealed object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -398,16 +412,28 @@ exports[`sealed object > crossSerializeAsync > supports Symbol.asyncIterator 1`]
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -609,8 +635,9 @@ exports[`sealed object > crossSerializeStream > scoped > supports Symbol.asyncIt
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -624,16 +651,28 @@ exports[`sealed object > crossSerializeStream > scoped > supports Symbol.asyncIt
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -885,8 +924,9 @@ exports[`sealed object > crossSerializeStream > supports Symbol.asyncIterator 1`
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -900,16 +940,28 @@ exports[`sealed object > crossSerializeStream > supports Symbol.asyncIterator 1`
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}
@@ -1173,8 +1225,9 @@ exports[`sealed object > serializeAsync > supports Symbol.asyncIterator 1`] = `
 	const internal = {
 		flush(value, mode, x) {
 			for (x = 0; x < count; x++) {
-				if (listeners[x]) {
-					listeners[x][mode](value);
+				const listener = listeners[x];
+				if (listener) {
+					listener[mode](value);
 				}
 			}
 		},
@@ -1188,16 +1241,28 @@ exports[`sealed object > serializeAsync > supports Symbol.asyncIterator 1`] = `
 				}
 			}
 		},
-		on(listener, temp) {
+		on(listener, temp = 0) {
+			let subscribed = alive;
 			if (alive) {
-				temp = count++;
+				for (temp = 0; temp < count; temp++) {
+					if (!listeners[temp]) {
+						break;
+					}
+				};
+				if (temp === count) {
+					count++;
+				};
 				listeners[temp] = listener;
 			};
 			internal.up(listener);
 			return () => {
-				if (alive) {
-					listeners[temp] = listeners[count];
-					listeners[count--] = undefined;
+				if (alive && subscribed) {
+					subscribed = false;
+					listeners[temp] = undefined;
+					while (count > 0 && !listeners[count - 1]) {
+						count--;
+					};
+					listeners.length = count;
 				}
 			};
 		}

--- a/packages/seroval/test/stream-listeners.test.ts
+++ b/packages/seroval/test/stream-listeners.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createStream, type StreamListener } from '../src';
+
+function listener(): StreamListener<number> {
+  return { next: vi.fn(), throw: vi.fn(), return: vi.fn() };
+}
+
+describe('stream listener cleanup', () => {
+  it('keeps other listeners subscribed after removing the first listener', () => {
+    const stream = createStream<number>();
+    const first = listener();
+    const second = listener();
+    const third = listener();
+    const offFirst = stream.on(first);
+    const offSecond = stream.on(second);
+    stream.on(third);
+    offFirst();
+    stream.next(1);
+    expect(first.next).not.toHaveBeenCalled();
+    expect(second.next).toHaveBeenCalledWith(1);
+    expect(third.next).toHaveBeenCalledWith(1);
+    offSecond();
+    stream.return(2);
+    expect(second.return).not.toHaveBeenCalled();
+    expect(third.return).toHaveBeenCalledWith(2);
+  });
+
+  it('makes cleanup idempotent when a slot is reused', () => {
+    const stream = createStream<number>();
+    const off = stream.on(listener());
+    off();
+    const second = listener();
+    stream.on(second);
+    off();
+    stream.next(1);
+    expect(second.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not skip the next listener when a callback unsubscribes itself', () => {
+    const stream = createStream<number>();
+    const first = listener();
+    const second = listener();
+    const off = stream.on(first);
+    first.next = off;
+    stream.on(second);
+    stream.next(1);
+    stream.next(2);
+    expect(second.next).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps duplicate listener registrations independent', () => {
+    const stream = createStream<number>();
+    const shared = listener();
+    const offFirst = stream.on(shared);
+    const offSecond = stream.on(shared);
+    offFirst();
+    offFirst();
+    stream.next(1);
+    expect(shared.next).toHaveBeenCalledTimes(1);
+    offSecond();
+    stream.next(2);
+    expect(shared.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('can remove a later listener during dispatch', () => {
+    const stream = createStream<number>();
+    const first = listener();
+    const second = listener();
+    const third = listener();
+    stream.on(first);
+    first.next = stream.on(second);
+    stream.on(third);
+    stream.next(1);
+    expect(second.next).not.toHaveBeenCalled();
+    expect(third.next).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores cleanup after completion', () => {
+    const stream = createStream<number>();
+    const first = listener();
+    const off = stream.on(first);
+    stream.return(1);
+    off();
+    off();
+    expect(first.return).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
With two listeners on a Seroval stream, unsubscribing the first prevents the second from receiving subsequent chunks. Repeated cleanup can also remove a later subscription, and unsubscribing during a callback can skip other listeners.

Keep subscription slots stable during dispatch, reuse vacant slots, and make cleanup idempotent. This preserves active consumers when another consumer leaves the stream.
