### PR TITLE
fix: release readable stream readers after errors

### DIFF
--- a/.changeset/release-errored-reader.md
+++ b/.changeset/release-errored-reader.md
@@ -1,0 +1,5 @@
+---
+'seroval-plugins': patch
+---
+
+Release ReadableStream reader locks when reading fails during async serialization.

--- a/packages/plugins/tests/web/stream-reader-cleanup.test.ts
+++ b/packages/plugins/tests/web/stream-reader-cleanup.test.ts
@@ -1,0 +1,39 @@
+import {
+  crossSerializeAsync,
+  serializeAsync,
+  toCrossJSONAsync,
+  toJSONAsync,
+} from 'seroval';
+import { describe, expect, it } from 'vitest';
+import ReadableStreamPlugin from '../../web/readable-stream';
+
+const serializers = [
+  ['serializeAsync', serializeAsync],
+  ['toJSONAsync', toJSONAsync],
+  ['crossSerializeAsync', crossSerializeAsync],
+  ['toCrossJSONAsync', toCrossJSONAsync],
+] as const;
+
+describe.each(serializers)('%s reader cleanup', (_name, serialize) => {
+  it.each([0, 3])(
+    'releases a reader that errors after %i chunks',
+    async chunks => {
+      const error = new Error('source failed');
+      let count = 0;
+      const source = new ReadableStream<number>({
+        pull(controller) {
+          if (count === chunks) {
+            controller.error(error);
+          } else {
+            controller.enqueue(count++);
+          }
+        },
+      });
+      await serialize(source, { plugins: [ReadableStreamPlugin] });
+      expect(source.locked).toBe(false);
+      const reader = source.getReader();
+      await expect(reader.read()).rejects.toBe(error);
+      reader.releaseLock();
+    },
+  );
+});

--- a/packages/plugins/web/readable-stream.ts
+++ b/packages/plugins/web/readable-stream.ts
@@ -71,6 +71,7 @@ async function drainStream<T>(
       await drainStream(stream, reader);
     }
   } catch (error) {
+    reader.releaseLock();
     stream.throw(error);
   }
 }


### PR DESCRIPTION
When a ReadableStream errors, the plugin forwards the error but keeps its reader locked. All four async serialization APIs leave `stream.locked === true` after they finish, so obtaining another reader throws a TypeError instead of allowing the caller to observe the original stream error.

Release the reader lock before forwarding the error, matching the existing cleanup on successful completion.
