### PR TITLE
fix: stop async iterators when serialization is cancelled

### DIFF
--- a/.changeset/cancel-async-iterator.md
+++ b/.changeset/cancel-async-iterator.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Stop pulling async iterators and call their return method when streaming serialization is cancelled.

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -289,6 +289,7 @@ function parseProperties(
             ? createStream()
             : createStreamFromAsyncIterable(
                 properties as unknown as AsyncIterable<unknown>,
+                ctx.state.cleanups,
               ),
         ) as SerovalNodeWithID,
       ),

--- a/packages/seroval/src/core/stream.ts
+++ b/packages/seroval/src/core/stream.ts
@@ -31,22 +31,46 @@ export function createStream<T>(): Stream<T> {
 
 export function createStreamFromAsyncIterable<T>(
   iterable: AsyncIterable<T>,
+  cleanups?: (() => void)[],
 ): Stream<T> {
   const stream = createStream<T>();
 
   const iterator = iterable[SYM_ASYNC_ITERATOR]();
+  let cancelled = false;
+  let done = false;
+
+  cleanups?.push(() => {
+    if (!(done || cancelled)) {
+      cancelled = true;
+      Promise.resolve()
+        .then(() => iterator.return?.())
+        .catch(() => {
+          // no-op
+        });
+    }
+  });
 
   async function push(): Promise<void> {
+    if (cancelled) {
+      return;
+    }
     try {
       const value = await iterator.next();
+      if (cancelled) {
+        return;
+      }
       if (value.done) {
+        done = true;
         stream.return(value.value as T);
       } else {
         stream.next(value.value);
         await push();
       }
     } catch (error) {
-      stream.throw(error);
+      done = true;
+      if (!cancelled) {
+        stream.throw(error);
+      }
     }
   }
 

--- a/packages/seroval/test/stream-cancellation.test.ts
+++ b/packages/seroval/test/stream-cancellation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { crossSerializeStream, toCrossJSONStream } from '../src';
+
+const serializers = [
+  [
+    'JSON',
+    (value: unknown, emit: () => void) =>
+      toCrossJSONStream(value, { onParse: emit }),
+  ],
+  [
+    'JavaScript',
+    (value: unknown, emit: () => void) =>
+      crossSerializeStream(value, { onSerialize: emit }),
+  ],
+] as const;
+
+describe.each(serializers)(
+  '%s async iterator cancellation',
+  (_name, serialize) => {
+    it('stops pulling and runs generator cleanup when serialization stops', async () => {
+      let pulled = 0;
+      let closed = false;
+      async function* source() {
+        await Promise.resolve();
+        try {
+          for (let i = 0; i < 1000; i++) {
+            pulled++;
+            yield i;
+          }
+        } finally {
+          closed = true;
+        }
+      }
+      let emitted = 0;
+      const cancel = serialize(source(), () => {
+        if (++emitted === 4) {
+          cancel();
+        }
+      });
+      await vi.waitFor(() => expect(closed).toBe(true));
+      expect(pulled).toBe(3);
+      expect(emitted).toBe(4);
+      cancel();
+      expect(pulled).toBe(3);
+    });
+
+    it('closes once and ignores a read that settles after cancellation', async () => {
+      let settle: (value: IteratorResult<number>) => void = vi.fn();
+      const pending = new Promise<IteratorResult<number>>(resolve => {
+        settle = resolve;
+      });
+      const next = vi
+        .fn<() => Promise<IteratorResult<number>>>()
+        .mockReturnValueOnce(pending)
+        .mockResolvedValue({ done: true, value: undefined });
+      const close = vi.fn(() =>
+        Promise.resolve({ done: true, value: undefined }),
+      );
+      const source = {
+        [Symbol.asyncIterator]() {
+          return { next, return: close };
+        },
+      };
+      const emit = vi.fn();
+      const cancel = serialize(source, emit);
+      cancel();
+      cancel();
+      settle({ done: false, value: 1 });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close an iterator that completed normally', async () => {
+      const next = vi.fn(() =>
+        Promise.resolve({ done: true, value: undefined }),
+      );
+      const close = vi.fn(() =>
+        Promise.resolve({ done: true, value: undefined }),
+      );
+      const source = {
+        [Symbol.asyncIterator]() {
+          return { next, return: close };
+        },
+      };
+      const cancel = serialize(source, vi.fn());
+      await new Promise(resolve => setTimeout(resolve, 0));
+      cancel();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    it.each(['throw', 'reject'])(
+      'handles an iterator return that can %s',
+      async mode => {
+        const next = vi
+          .fn<() => Promise<IteratorResult<number>>>()
+          .mockResolvedValueOnce({ done: false, value: 1 })
+          .mockResolvedValue({ done: true, value: undefined });
+        const close = vi.fn(() => {
+          const error = new Error('cleanup failed');
+          if (mode === 'throw') {
+            throw error;
+          }
+          return Promise.reject(error);
+        });
+        const source = {
+          [Symbol.asyncIterator]() {
+            return { next, return: close };
+          },
+        };
+        const cancel = serialize(source, vi.fn());
+        cancel();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(close).toHaveBeenCalledTimes(1);
+      },
+    );
+  },
+);


### PR DESCRIPTION
Cancelling streaming serialization stops output but keeps consuming async iterators. A 1,000-value generator cancelled after its third value still produces all 1,000 values; an unbounded source keeps running after its consumer has left.

Register async iterators with the existing streaming cleanup lifecycle. Cancellation stops further pulls, ignores an already-pending read, and calls `iterator.return()` once so generators can run their cleanup. The same reproduction now stops after three values.

Related to #76; the earlier cleanup fix covered ReadableStreams.
