### PR TITLE
fix: validate array nodes before allocation

### DIFF
--- a/.changeset/validate-array-node.md
+++ b/.changeset/validate-array-node.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Reject malformed array nodes before using their length to allocate or iterate during JSON deserialization.

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -260,6 +260,9 @@ function deserializeArray(
   node: SerovalArrayNode,
 ): unknown[] {
   const items = node.a;
+  if (!Array.isArray(items)) {
+    throw new SerovalMalformedNodeError(node);
+  }
   const len = items.length;
   const result: unknown[] = assignIndexedValue(
     ctx,

--- a/packages/seroval/test/array-node-validation.test.ts
+++ b/packages/seroval/test/array-node-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fromCrossJSON,
+  fromJSON,
+  SerovalMalformedNodeError,
+  toCrossJSON,
+  toJSON,
+} from '../src';
+
+describe('array node validation', () => {
+  it.each([null, {}, { length: 0 }, { length: 1000000 }, 'not an array'])(
+    'rejects non-array items %j in both JSON formats',
+    items => {
+      const node = JSON.parse(JSON.stringify({ ...toCrossJSON([]), a: items }));
+      const expected = expect.objectContaining({
+        cause: expect.any(SerovalMalformedNodeError),
+      });
+      expect(() => fromJSON({ ...toJSON([]), t: node })).toThrow(expected);
+      expect(() => fromCrossJSON(node, { refs: new Map() })).toThrow(expected);
+    },
+  );
+
+  it('rejects a non-array before reading its declared length', () => {
+    const node = {
+      ...toCrossJSON([]),
+      a: {
+        get length() {
+          throw new Error('length must not be read');
+        },
+      },
+    };
+    expect(() =>
+      fromCrossJSON(node as unknown as ReturnType<typeof toCrossJSON>, {
+        refs: new Map(),
+      }),
+    ).toThrow(
+      expect.objectContaining({ cause: expect.any(SerovalMalformedNodeError) }),
+    );
+  });
+
+  it.each([{ value: [] }, { value: [1, 2] }, { value: new Array(3) }])(
+    'preserves valid arrays $value',
+    ({ value }) => {
+      expect(fromJSON(toJSON(value))).toStrictEqual(value);
+      expect(
+        fromCrossJSON(toCrossJSON(value), { refs: new Map() }),
+      ).toStrictEqual(value);
+    },
+  );
+});


### PR DESCRIPTION
Array deserialization trusts the items field's `length` without checking that the field is an array. A malformed 63-byte JSON payload can allocate a million-element array, consuming roughly 8 MB of heap and several milliseconds of CPU despite containing no array elements.

Require an actual array before reading its length, allocating the result, or iterating. Malformed inputs now fail with `SerovalMalformedNodeError` through the existing deserialization error wrapper; valid arrays, including sparse arrays, keep their existing behavior.
