### PR TITLE
feat: add native base64, compact views, and configurable decode limits

### DIFF
--- a/.changeset/compact-binary-buffers.md
+++ b/.changeset/compact-binary-buffers.md
@@ -1,0 +1,5 @@
+---
+'seroval': minor
+---
+
+Use native base64 encoding when available. Add opt-in compact ArrayBuffer views and a configurable JSON deserialization base64 limit while preserving the existing defaults.

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -241,6 +241,64 @@ The mentioned serialization methods are ideal for server-to-client communication
 | deserialization | `deserialize` | `fromJSON` |
 | cross-deserialization | `deserialize` | `fromCrossJSON` |
 
+## Binary values
+
+ArrayBuffers are encoded as base64. Seroval uses native Node or browser encoding
+when available, with a fallback for runtimes without either API.
+
+### Compact typed arrays and DataViews
+
+By default, Seroval preserves each view's full backing buffer, byte offset, and
+shared-buffer identity. A small view can therefore serialize a much larger buffer,
+including bytes outside the view.
+
+Pass `compactArrayBufferViews: true` to serialize only each view's visible bytes:
+
+```ts
+import { toJSON, fromJSON } from 'seroval';
+
+const view = new Uint8Array(new ArrayBuffer(512 * 1024), 128, 1024);
+const result = fromJSON<Uint8Array>(
+  toJSON(view, { compactArrayBufferViews: true }),
+);
+
+result.byteOffset; // 0
+result.buffer.byteLength; // 1024
+```
+
+This option applies to all serialization modes and `Serializer`. Each distinct
+view gets its own copied buffer, even when views overlap or span the entire
+original buffer. Repeated references to the same view still refer to the same
+deserialized view. The original values are not changed.
+
+Compaction intentionally breaks buffer sharing between distinct views and any
+separately serialized backing buffer. If the input also contains the backing
+ArrayBuffer itself, that buffer is still serialized in full. Use the default when
+buffer identity or offsets matter.
+
+### JSON decoding limits
+
+Serialization can produce buffers larger than the default JSON decoding limit.
+`fromJSON` and `fromCrossJSON` accept `maxBase64Length` to set a receiver-owned
+limit, measured in encoded characters per ArrayBuffer. The default remains
+1,000,000 characters (up to 750,000 decoded bytes).
+
+```ts
+const buffer = new ArrayBuffer(1024 * 1024);
+const json = toJSON(buffer);
+
+// A 1 MiB buffer requires 1,398,104 base64 characters.
+const result = fromJSON<ArrayBuffer>(json, { maxBase64Length: 1_398_104 });
+```
+
+The limit must be a non-negative safe integer. Zero permits only empty buffers.
+Oversized input is rejected before base64 decoding or allocating its output
+buffer, with a `RangeError` cause inside `SerovalDeserializationError`. Invalid
+option values throw `RangeError` when the deserializer is created. Set the limit
+according to the receiving application's needs; it is a per-buffer limit, not a
+total payload or memory budget. JavaScript evaluation through `deserialize` does
+not use these JSON decoding limits.
+
 ## Push-based streaming serialization
 
 > [!NOTE]

--- a/packages/seroval/src/core/Serializer.ts
+++ b/packages/seroval/src/core/Serializer.ts
@@ -1,8 +1,8 @@
 import { crossSerializeStream } from './cross';
 import {
-  resolvePlugins,
   type Plugin,
   type PluginAccessOptions,
+  resolvePlugins,
 } from './plugin';
 import { serializeString } from './string';
 
@@ -10,6 +10,7 @@ export interface SerializerOptions extends PluginAccessOptions {
   globalIdentifier: string;
   scopeId?: string;
   disabledFeatures?: number;
+  compactArrayBufferViews?: boolean;
   onData: (result: string) => void;
   onError: (error: unknown) => void;
   onDone?: () => void;
@@ -46,6 +47,7 @@ export default class Serializer {
           scopeId: this.options.scopeId,
           refs: this.refs,
           disabledFeatures: this.options.disabledFeatures,
+          compactArrayBufferViews: this.options.compactArrayBufferViews,
           onError: this.options.onError,
           onSerialize: (data, initial) => {
             if (this.alive) {

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -24,7 +24,11 @@ import {
 } from '../base-primitives';
 import { Feature } from '../compat';
 import { NIL, SerovalNodeType, SerovalTemporalType } from '../constants';
-import { SerovalDepthLimitError, SerovalParserError, SerovalUnsupportedTypeError } from '../errors';
+import {
+  SerovalDepthLimitError,
+  SerovalParserError,
+  SerovalUnsupportedTypeError,
+} from '../errors';
 import { FALSE_NODE, NULL_NODE, TRUE_NODE, UNDEFINED_NODE } from '../literals';
 import { createSerovalNode } from '../node';
 import { OpaqueReference } from '../opaque-reference';
@@ -77,11 +81,12 @@ import {
   createBaseParserContext,
   createMapNode,
   createObjectNode,
+  getArrayBufferView,
   getReferenceNode,
   markParserRef,
+  ParserNodeType,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
-  ParserNodeType,
   parseSpecialReference,
   parseWellKnownSymbol,
 } from './parser';
@@ -235,6 +240,7 @@ async function parseTypedArray(
   id: number,
   current: TypedArrayValue,
 ): Promise<SerovalTypedArrayNode> {
+  current = getArrayBufferView(ctx.base, current);
   return createTypedArrayNode(
     id,
     current,
@@ -248,6 +254,7 @@ async function parseBigIntTypedArray(
   id: number,
   current: BigIntTypedArrayValue,
 ): Promise<SerovalBigIntTypedArrayNode> {
+  current = getArrayBufferView(ctx.base, current);
   return createBigIntTypedArrayNode(
     id,
     current,
@@ -261,6 +268,7 @@ async function parseDataView(
   id: number,
   current: DataView,
 ): Promise<SerovalDataViewNode> {
+  current = getArrayBufferView(ctx.base, current);
   return createDataViewNode(
     id,
     current,

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -69,7 +69,7 @@ import type {
 import { getTypedArrayConstructor } from '../utils/typed-array';
 import { isValidKey, isValidSymbol } from '../utils/valid-properties';
 
-const MAX_BASE64_LENGTH = 1_000_000; // ~0.75MB decoded
+const DEFAULT_MAX_BASE64_LENGTH = 1_000_000; // ~0.75MB decoded
 const MAX_BIGINT_LENGTH = 10_000;
 const MAX_REGEXP_SOURCE_LENGTH = 20_000;
 
@@ -94,6 +94,8 @@ export interface BaseDeserializerContextOptions extends PluginAccessOptions {
   features?: number;
   disabledFeatures?: number;
   depthLimit?: number;
+  /** Maximum encoded characters per ArrayBuffer. Defaults to 1,000,000. */
+  maxBase64Length?: number;
 }
 
 export interface BaseDeserializerContext extends PluginAccessOptions {
@@ -104,6 +106,7 @@ export interface BaseDeserializerContext extends PluginAccessOptions {
   refs: Map<number, unknown> & { types: Map<number, SerovalNodeType> };
   features: number;
   depthLimit: number;
+  maxBase64Length: number;
 }
 
 const DEFAULT_DEPTH_LIMIT = 1000;
@@ -112,6 +115,10 @@ export function createBaseDeserializerContext(
   mode: SerovalMode,
   options: BaseDeserializerContextOptions,
 ): BaseDeserializerContext {
+  const maxBase64Length = options.maxBase64Length ?? DEFAULT_MAX_BASE64_LENGTH;
+  if (!Number.isSafeInteger(maxBase64Length) || maxBase64Length < 0) {
+    throw new RangeError('maxBase64Length must be a non-negative safe integer');
+  }
   const refs = options.refs || new Map();
   if (!('types' in refs)) {
     Object.assign(refs, {
@@ -124,6 +131,7 @@ export function createBaseDeserializerContext(
     refs: refs as BaseDeserializerContext['refs'],
     features: options.features ?? ALL_ENABLED ^ (options.disabledFeatures || 0),
     depthLimit: options.depthLimit || DEFAULT_DEPTH_LIMIT,
+    maxBase64Length,
   };
 }
 
@@ -471,8 +479,13 @@ function deserializeArrayBuffer(
   ctx: DeserializerContext,
   node: SerovalArrayBufferNode,
 ): ArrayBuffer {
-  if (node.s.length > MAX_BASE64_LENGTH) {
+  if (typeof node.s !== 'string') {
     throw new SerovalMalformedNodeError(node);
+  }
+  if (node.s.length > ctx.base.maxBase64Length) {
+    throw new RangeError(
+      'ArrayBuffer exceeds maxBase64Length (' + ctx.base.maxBase64Length + ')',
+    );
   }
   const result = assignIndexedValue(
     ctx,

--- a/packages/seroval/src/core/context/parser.ts
+++ b/packages/seroval/src/core/context/parser.ts
@@ -16,7 +16,6 @@ import {
   SPECIAL_REFS,
   SpecialReference,
 } from '../special-reference';
-import { serializeString } from '../string';
 import { SYM_ASYNC_ITERATOR, SYM_ITERATOR } from '../symbols';
 import type {
   SerovalArrayBufferNode,
@@ -39,6 +38,8 @@ export interface BaseParserContextOptions extends PluginAccessOptions {
   disabledFeatures?: number;
   refs?: Map<unknown, number>;
   depthLimit?: number;
+  /** Copy each typed array or DataView's visible bytes into its own buffer. */
+  compactArrayBufferViews?: boolean;
 }
 
 export const enum ParserNodeType {
@@ -74,6 +75,7 @@ export interface BaseParserContext extends PluginAccessOptions {
   features: number;
 
   depthLimit: number;
+  compactArrayBufferViews: boolean;
 }
 
 export function createBaseParserContext(
@@ -87,6 +89,7 @@ export function createBaseParserContext(
     features: ALL_ENABLED ^ (options.disabledFeatures || 0),
     refs: options.refs || new Map(),
     depthLimit: options.depthLimit || 1000,
+    compactArrayBufferViews: options.compactArrayBufferViews ?? false,
   };
 }
 
@@ -308,20 +311,46 @@ export function createPromiseConstructorNode(
   );
 }
 
+export function getArrayBufferView<T extends ArrayBufferView>(
+  ctx: BaseParserContext,
+  current: T,
+): T {
+  if (!ctx.compactArrayBufferViews) {
+    return current;
+  }
+  const buffer = new Uint8Array(
+    current.buffer,
+    current.byteOffset,
+    current.byteLength,
+  ).slice().buffer;
+  const Constructor = current.constructor as new (buffer: ArrayBuffer) => T;
+  return new Constructor(buffer);
+}
+
+function encodeArrayBuffer(current: ArrayBuffer): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(current).toString('base64');
+  }
+  const bytes = new Uint8Array(current);
+  if (typeof bytes.toBase64 === 'function') {
+    return bytes.toBase64();
+  }
+  let result = '';
+  for (let i = 0, len = bytes.length; i < len; i++) {
+    result += String.fromCharCode(bytes[i]);
+  }
+  return btoa(result);
+}
+
 export function createArrayBufferNode(
   ctx: BaseParserContext,
   id: number,
   current: ArrayBuffer,
 ): SerovalArrayBufferNode {
-  const bytes = new Uint8Array(current);
-  let result = '';
-  for (let i = 0, len = bytes.length; i < len; i++) {
-    result += String.fromCharCode(bytes[i]);
-  }
   return createSerovalNode(
     SerovalNodeType.ArrayBuffer,
     id,
-    serializeString(btoa(result)),
+    encodeArrayBuffer(current),
     NIL,
     NIL,
     NIL,

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -85,10 +85,11 @@ import {
   createMapNode,
   createObjectNode,
   createPromiseConstructorNode,
+  getArrayBufferView,
   getReferenceNode,
+  ParserNodeType,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
-  ParserNodeType,
   parseSpecialReference,
   parseWellKnownSymbol,
 } from './parser';
@@ -340,6 +341,7 @@ function parseTypedArray(
   id: number,
   current: TypedArrayValue,
 ): SerovalTypedArrayNode {
+  current = getArrayBufferView(ctx.base, current);
   return createTypedArrayNode(
     id,
     current,
@@ -353,6 +355,7 @@ function parseBigIntTypedArray(
   id: number,
   current: BigIntTypedArrayValue,
 ): SerovalBigIntTypedArrayNode {
+  current = getArrayBufferView(ctx.base, current);
   return createBigIntTypedArrayNode(
     id,
     current,
@@ -366,6 +369,7 @@ function parseDataView(
   id: number,
   current: DataView,
 ): SerovalDataViewNode {
+  current = getArrayBufferView(ctx.base, current);
   return createDataViewNode(id, current, parseSOS(ctx, depth, current.buffer));
 }
 

--- a/packages/seroval/src/core/cross/index.ts
+++ b/packages/seroval/src/core/cross/index.ts
@@ -37,6 +37,7 @@ export function crossSerialize<T>(
 ): string {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Cross, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -61,6 +62,7 @@ export async function crossSerializeAsync<T>(
 ): Promise<string> {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Cross, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -83,6 +85,7 @@ export function toCrossJSON<T>(
 ): SerovalNode {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Cross, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -98,6 +101,7 @@ export async function toCrossJSONAsync<T>(
 ): Promise<SerovalNode> {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Cross, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -117,6 +121,7 @@ export function crossSerializeStream<T>(
 ): () => void {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createStreamParserContext({
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     refs: options.refs,
     disabledFeatures: options.disabledFeatures,
@@ -158,6 +163,7 @@ export function toCrossJSONStream<T>(
 ): () => void {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createStreamParserContext({
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     refs: options.refs,
     disabledFeatures: options.disabledFeatures,
@@ -180,6 +186,7 @@ export function fromCrossJSON<T>(
 ): T {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createCrossDeserializerContext({
+    maxBase64Length: options.maxBase64Length,
     plugins,
     refs: options.refs,
     features: options.features,

--- a/packages/seroval/src/core/tree/index.ts
+++ b/packages/seroval/src/core/tree/index.ts
@@ -1,8 +1,10 @@
+import { ALL_ENABLED } from '../compat';
 import {
   createAsyncParserContext,
   parseTopAsync,
 } from '../context/async-parser';
 import {
+  type BaseDeserializerContextOptions,
   createVanillaDeserializerContext,
   deserializeTop,
 } from '../context/deserializer';
@@ -18,7 +20,6 @@ import {
   SerovalMode,
 } from '../plugin';
 import type { SerovalNode } from '../types';
-import { ALL_ENABLED } from '../compat';
 export type SyncParserContextOptions = Omit<BaseParserContextOptions, 'refs'>;
 export type AsyncParserContextOptions = Omit<BaseParserContextOptions, 'refs'>;
 
@@ -28,6 +29,7 @@ export function serialize<T>(
 ): string {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Vanilla, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -46,6 +48,7 @@ export async function serializeAsync<T>(
 ): Promise<string> {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Vanilla, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -68,7 +71,9 @@ export interface SerovalJSON {
   m: number[];
 }
 
-export interface FromJSONOptions extends PluginAccessOptions {
+export interface FromJSONOptions
+  extends PluginAccessOptions,
+    Pick<BaseDeserializerContextOptions, 'maxBase64Length'> {
   disabledFeatures?: number;
 }
 
@@ -78,6 +83,7 @@ export function toJSON<T>(
 ): SerovalJSON {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Vanilla, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -94,6 +100,7 @@ export async function toJSONAsync<T>(
 ): Promise<SerovalJSON> {
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Vanilla, {
+    compactArrayBufferViews: options.compactArrayBufferViews,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -125,6 +132,7 @@ export function fromJSON<T>(
   const disabledFeatures = options.disabledFeatures || 0;
   const sourceFeatures = source.f ?? ALL_ENABLED;
   const ctx = createVanillaDeserializerContext({
+    maxBase64Length: options.maxBase64Length,
     plugins,
     markedRefs: source.m,
     features: sourceFeatures & ~disabledFeatures,

--- a/packages/seroval/test/binary.test.ts
+++ b/packages/seroval/test/binary.test.ts
@@ -1,0 +1,322 @@
+import { Buffer } from 'node:buffer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type BaseParserContextOptions,
+  crossSerialize,
+  crossSerializeAsync,
+  crossSerializeStream,
+  deserialize,
+  fromCrossJSON,
+  fromJSON,
+  Serializer,
+  SerovalDeserializationError,
+  SerovalMalformedNodeError,
+  serialize,
+  serializeAsync,
+  toCrossJSON,
+  toCrossJSONAsync,
+  toCrossJSONStream,
+  toJSON,
+  toJSONAsync,
+} from '../src';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('binary encoding', () => {
+  it('encodes binary values in Node without btoa', () => {
+    vi.stubGlobal('btoa', undefined);
+    expect(toJSON(new Uint8Array([0, 127, 255]).buffer).t.s).toBe('AH//');
+  });
+  for (const native of [true, false]) {
+    it(`preserves all byte values and base64 padding (native: ${native})`, () => {
+      if (!native) {
+        vi.stubGlobal('Buffer', undefined);
+      }
+      for (const length of [0, 1, 2, 3, 256, 257, 258, 4096]) {
+        const bytes = Uint8Array.from({ length }, (_, i) => i % 256);
+        const json = toJSON(bytes.buffer);
+        expect(json.t.s).toBe(Buffer.from(bytes).toString('base64'));
+        expect(new Uint8Array(fromJSON<ArrayBuffer>(json))).toEqual(bytes);
+        expect(
+          new Uint8Array(deserialize<ArrayBuffer>(serialize(bytes.buffer))),
+        ).toEqual(bytes);
+      }
+    });
+  }
+});
+
+describe('compact ArrayBuffer views', () => {
+  it('preserves backing-buffer identity and offsets by default', () => {
+    const buffer = new ArrayBuffer(32);
+    const view = new Uint8Array(buffer, 8, 8);
+    const back = fromJSON<{ buffer: ArrayBuffer; view: Uint8Array }>(
+      toJSON({ buffer, view }),
+    );
+    expect(back.view.buffer).toBe(back.buffer);
+    expect(back.view.byteOffset).toBe(8);
+    expect(back.buffer.byteLength).toBe(32);
+  });
+
+  it('preserves floating-point bytes, including NaN payloads and negative zero', () => {
+    const buffer = new ArrayBuffer(16);
+    new Uint32Array(buffer, 4, 2).set([0x7fc00001, 0x80000000]);
+    const view = new Float32Array(buffer, 4, 2);
+    const back = fromJSON<Float32Array>(
+      toJSON(view, { compactArrayBufferViews: true }),
+    );
+    expect(new Uint8Array(back.buffer)).toEqual(new Uint8Array(buffer, 4, 8));
+  });
+  it('serializes only the visible bytes when explicitly enabled', () => {
+    const buffer = new ArrayBuffer(512 * 1024);
+    const view = new Uint8Array(buffer, 128, 1024);
+    view.fill(42);
+    const back = fromJSON<Uint8Array>(
+      toJSON(view, { compactArrayBufferViews: true }),
+    );
+    expect(back).toEqual(view);
+    expect(back.byteOffset).toBe(0);
+    expect(back.buffer.byteLength).toBe(view.byteLength);
+  });
+
+  const modes: Record<
+    string,
+    (value: unknown, options: BaseParserContextOptions) => unknown
+  > = {
+    serialize: (value, options) => deserialize(serialize(value, options)),
+    serializeAsync: async (value, options) =>
+      deserialize(await serializeAsync(Promise.resolve(value), options)),
+    toJSON: (value, options) => fromJSON(toJSON(value, options)),
+    toJSONAsync: async (value, options) =>
+      fromJSON(await toJSONAsync(Promise.resolve(value), options)),
+    crossSerialize: (value, options) =>
+      new Function('$R', `return (${crossSerialize(value, options)})`)([]),
+    crossSerializeAsync: async (value, options) =>
+      new Function(
+        '$R',
+        `return (${await crossSerializeAsync(Promise.resolve(value), options)})`,
+      )([]),
+    toCrossJSON: (value, options) =>
+      fromCrossJSON(toCrossJSON(value, options), { refs: new Map() }),
+    toCrossJSONAsync: async (value, options) =>
+      fromCrossJSON(await toCrossJSONAsync(Promise.resolve(value), options), {
+        refs: new Map(),
+      }),
+    toCrossJSONStream: (value, options) =>
+      new Promise((resolve, reject) => {
+        const refs = new Map();
+        let back: unknown;
+        toCrossJSONStream(Promise.resolve(value), {
+          ...options,
+          onParse(node, initial) {
+            const result = fromCrossJSON(node, { refs });
+            if (initial) {
+              back = result;
+            }
+          },
+          onDone() {
+            resolve(back);
+          },
+          onError: reject,
+        });
+      }),
+    crossSerializeStream: (value, options) =>
+      new Promise((resolve, reject) => {
+        const refs: unknown[] = [];
+        let back: unknown;
+        crossSerializeStream(Promise.resolve(value), {
+          ...options,
+          onSerialize(source, initial) {
+            const result = new Function('$R', `return (${source})`)(refs);
+            if (initial) {
+              back = result;
+            }
+          },
+          onDone() {
+            resolve(back);
+          },
+          onError: reject,
+        });
+      }),
+    Serializer: (value, options) =>
+      new Promise((resolve, reject) => {
+        const values: Record<string, unknown> = {};
+        const refs: unknown[] = [];
+        const serializer = new Serializer({
+          ...options,
+          globalIdentifier: 'values',
+          onData(source) {
+            new Function('values', '$R', source)(values, refs);
+          },
+          onDone() {
+            resolve(values.value);
+          },
+          onError: reject,
+        });
+        serializer.write('value', Promise.resolve(value));
+        serializer.flush();
+      }),
+  };
+
+  for (const [name, roundTrip] of Object.entries(modes)) {
+    for (const compactArrayBufferViews of [false, true]) {
+      it(`preserves view identity and the selected buffer semantics in ${name} (compact: ${compactArrayBufferViews})`, async () => {
+        const buffer = Uint8Array.from({ length: 32 }, (_, i) => i).buffer;
+        const first = new Uint8Array(buffer, 8, 8);
+        const second = new Uint16Array(buffer, 8, 4);
+        const full = new Uint8Array(buffer);
+        const input = { first, again: first, second, full, buffer };
+        const back = (await roundTrip(input, {
+          compactArrayBufferViews,
+        })) as typeof input;
+        expect(back.first).toEqual(first);
+        expect(back.second).toEqual(second);
+        expect(back.full).toEqual(full);
+        expect(back.first).toBe(back.again);
+        expect(back.first.byteOffset).toBe(compactArrayBufferViews ? 0 : 8);
+        expect(back.first.buffer.byteLength).toBe(
+          compactArrayBufferViews ? 8 : 32,
+        );
+        if (compactArrayBufferViews) {
+          expect(back.first.buffer).not.toBe(back.second.buffer);
+          expect(back.full.buffer).not.toBe(back.buffer);
+        } else {
+          expect(back.first.buffer).toBe(back.second.buffer);
+          expect(back.first.buffer).toBe(back.buffer);
+          expect(back.full.buffer).toBe(back.buffer);
+        }
+        expect(new Uint8Array(back.buffer)).toEqual(full);
+        expect(first.byteOffset).toBe(8);
+        expect(first.buffer).toBe(buffer);
+      });
+    }
+
+    it(`compacts every supported view type, including empty views, in ${name}`, async () => {
+      const buffer = Uint8Array.from({ length: 32 }, (_, i) => i).buffer;
+      const constructors: (new (
+        buffer: ArrayBuffer,
+        byteOffset: number,
+        length: number,
+      ) => ArrayBufferView<ArrayBuffer>)[] = [
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array,
+        BigInt64Array,
+        BigUint64Array,
+        DataView,
+      ];
+      const views = constructors.flatMap(Constructor => [
+        new Constructor(buffer, 8, 2),
+        new Constructor(buffer, 32, 0),
+      ]);
+      const back = (await roundTrip(views, {
+        compactArrayBufferViews: true,
+      })) as typeof views;
+      for (let i = 0; i < views.length; i++) {
+        expect(back[i].constructor).toBe(views[i].constructor);
+        expect(back[i].byteOffset).toBe(0);
+        expect(back[i].buffer.byteLength).toBe(views[i].byteLength);
+        expect(new Uint8Array(back[i].buffer)).toEqual(
+          new Uint8Array(buffer, views[i].byteOffset, views[i].byteLength),
+        );
+      }
+    });
+  }
+});
+
+describe('binary decoding limits', () => {
+  it('allows a 1 MiB buffer with an explicit receiver limit', () => {
+    const bytes = new Uint8Array(1024 * 1024).fill(42);
+    const json = toJSON(bytes.buffer);
+    expect(() => fromJSON(json)).toThrow();
+    const back = fromJSON<ArrayBuffer>(json, { maxBase64Length: 1_398_104 });
+    expect(Buffer.from(back).equals(Buffer.from(bytes))).toBe(true);
+  });
+
+  for (const cross of [false, true]) {
+    const encode = (value: unknown) =>
+      cross ? toCrossJSON(value) : toJSON(value).t;
+    const decode = (
+      node: ReturnType<typeof encode>,
+      maxBase64Length?: number,
+    ) =>
+      cross
+        ? fromCrossJSON<ArrayBuffer>(node, { refs: new Map(), maxBase64Length })
+        : fromJSON<ArrayBuffer>(
+            { t: node, m: [], f: toJSON(null).f },
+            { maxBase64Length },
+          );
+
+    it(`enforces the default and configured boundaries (cross: ${cross})`, () => {
+      expect(decode(encode(new ArrayBuffer(750_000))).byteLength).toBe(750_000);
+      expect(() => decode(encode(new ArrayBuffer(750_001)))).toThrow(
+        SerovalDeserializationError,
+      );
+      expect(
+        decode(encode(new ArrayBuffer(1024 * 1024)), 1_398_104).byteLength,
+      ).toBe(1024 * 1024);
+      expect(() =>
+        decode(encode(new ArrayBuffer(1024 * 1024)), 1_398_103),
+      ).toThrow(SerovalDeserializationError);
+      expect(decode(encode(new ArrayBuffer(0)), 0).byteLength).toBe(0);
+      expect(() => decode(encode(new ArrayBuffer(1)), 0)).toThrow(
+        SerovalDeserializationError,
+      );
+      expect(decode(encode(new ArrayBuffer(3)), 4).byteLength).toBe(3);
+      expect(() => decode(encode(new ArrayBuffer(4)), 4)).toThrow(
+        SerovalDeserializationError,
+      );
+    });
+
+    it(`rejects invalid limits without disabling protection (cross: ${cross})`, () => {
+      for (const limit of [
+        -1,
+        0.5,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.MAX_SAFE_INTEGER + 1,
+      ]) {
+        expect(() => decode(encode(new ArrayBuffer(0)), limit)).toThrow(
+          RangeError,
+        );
+      }
+    });
+
+    it(`rejects malformed base64 fields and reports oversize input (cross: ${cross})`, () => {
+      for (const value of [null, 123, {}, { length: 0 }, ['AA==']]) {
+        const node = { ...encode(new ArrayBuffer(0)), s: value } as ReturnType<
+          typeof encode
+        >;
+        try {
+          decode(node);
+          expect.unreachable();
+        } catch (error) {
+          expect(error).toBeInstanceOf(SerovalDeserializationError);
+          expect((error as SerovalDeserializationError).cause).toBeInstanceOf(
+            SerovalMalformedNodeError,
+          );
+        }
+      }
+      try {
+        decode(encode(new ArrayBuffer(3)), 0);
+        expect.unreachable();
+      } catch (error) {
+        expect((error as SerovalDeserializationError).cause).toEqual(
+          new RangeError('ArrayBuffer exceeds maxBase64Length (0)'),
+        );
+      }
+      expect(() =>
+        decode({ ...encode(new ArrayBuffer(0)), s: '!!!!' } as ReturnType<
+          typeof encode
+        >),
+      ).toThrow();
+    });
+  }
+});


### PR DESCRIPTION
Binary serialization currently builds an intermediate byte string before base64 encoding. Use native Node or browser encoding when available, keeping the existing fallback and output format. On Node 24.14.1, serializing a 1 MiB ArrayBuffer to Seroval JSON dropped from 26.82 ms to 0.23 ms. These measure serialization, not request latency; memory savings were not measured.

Add `compactArrayBufferViews` for callers who want only a typed array or DataView's visible bytes. A 1 KiB view into a 512 KiB buffer drops from 699,172 to 1,486 bytes of JSON. Compaction is opt-in: defaults preserve offsets and shared buffers; compact mode gives distinct views separate buffers while preserving repeated references to the same view.

Add `maxBase64Length` to JSON deserialization so a successfully serialized 1 MiB buffer can be accepted with an explicit receiver limit. Keep the existing 1,000,000-character default, reject invalid limits, and report oversized buffers before decoding or allocating their output. The limit remains per buffer.

Validation: 842 Seroval tests and 169 plugin tests pass, both package builds pass, and Chrome passes native and fallback binary round-trips. Changed files pass Biome with existing warnings. Standalone TypeScript checking reproduces the same 27 diagnostics on unchanged upstream and this branch, with no added errors. Includes documentation and a minor changeset for the new options.
