### PR TITLE
perf: accelerate JSON binary decoding in Node

### DIFF
--- a/.changeset/native-binary-decoding.md
+++ b/.changeset/native-binary-decoding.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Reduce JSON binary decoding time in Node while preserving base64 validation and the browser fallback.

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -70,6 +70,7 @@ import { getTypedArrayConstructor } from '../utils/typed-array';
 import { isValidKey, isValidSymbol } from '../utils/valid-properties';
 
 const DEFAULT_MAX_BASE64_LENGTH = 1_000_000; // ~0.75MB decoded
+const MIN_NATIVE_BASE64_LENGTH = 512;
 const MAX_BIGINT_LENGTH = 10_000;
 const MAX_REGEXP_SOURCE_LENGTH = 20_000;
 
@@ -487,12 +488,22 @@ function deserializeArrayBuffer(
       'ArrayBuffer exceeds maxBase64Length (' + ctx.base.maxBase64Length + ')',
     );
   }
-  const result = assignIndexedValue(
-    ctx,
-    node.i,
-    ARRAY_BUFFER_CONSTRUCTOR(deserializeString(node.s)),
-  );
-  return result;
+  const source = deserializeString(node.s);
+  let buffer: ArrayBuffer;
+  if (
+    source.length < MIN_NATIVE_BASE64_LENGTH ||
+    typeof Buffer === 'undefined'
+  ) {
+    buffer = ARRAY_BUFFER_CONSTRUCTOR(source);
+  } else {
+    // Keep atob's validation; Buffer's base64 decoder accepts malformed input.
+    const bytes = Buffer.from(atob(source), 'latin1');
+    buffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+  }
+  return assignIndexedValue(ctx, node.i, buffer);
 }
 
 function deserializeTypedArray(

--- a/packages/seroval/test/binary.bench.ts
+++ b/packages/seroval/test/binary.bench.ts
@@ -1,0 +1,12 @@
+import { bench, describe } from 'vitest';
+import { fromJSON, toJSON } from '../src';
+
+for (const length of [0, 64, 381, 384, 1024, 64 * 1024, 512 * 1024]) {
+  const value = Uint8Array.from({ length }, (_, i) => i % 256).buffer;
+  const json = toJSON(value);
+  describe(`${length} bytes`, () => {
+    bench('fromJSON', () => {
+      fromJSON(json);
+    });
+  });
+}

--- a/packages/seroval/test/binary.test.ts
+++ b/packages/seroval/test/binary.test.ts
@@ -47,6 +47,61 @@ describe('binary encoding', () => {
   }
 });
 
+describe('binary decoding validation', () => {
+  for (const native of [true, false]) {
+    it(`preserves accepted padding and whitespace (native: ${native})`, () => {
+      if (!native) {
+        vi.stubGlobal('Buffer', undefined);
+      }
+      for (const [source, expected] of [
+        ['', []],
+        ['YQ', [97]],
+        ['YQ==', [97]],
+        ['YWI', [97, 98]],
+        ['YWI=', [97, 98]],
+        [' Y\tW\nI=\r', [97, 98]],
+      ] as const) {
+        for (const padding of ['', ' '.repeat(512)]) {
+          const json = toJSON(new ArrayBuffer(0));
+          json.t.s = padding + source;
+          const back = fromJSON<ArrayBuffer>(json);
+          expect(back.byteLength).toBe(expected.length);
+          expect([...new Uint8Array(back)]).toEqual(expected);
+        }
+      }
+    });
+
+    it(`rejects malformed base64 (native: ${native})`, () => {
+      if (!native) {
+        vi.stubGlobal('Buffer', undefined);
+      }
+      for (const source of ['!!!!', 'YQ=', 'YQ===', '_w==', 'A', 'YQ==A']) {
+        for (const padding of ['', ' '.repeat(512)]) {
+          const json = toJSON(new ArrayBuffer(0));
+          json.t.s = padding + source;
+          expect(() => fromJSON(json)).toThrow(SerovalDeserializationError);
+          expect(() => fromCrossJSON(json.t, { refs: new Map() })).toThrow(
+            SerovalDeserializationError,
+          );
+        }
+      }
+    });
+  }
+
+  it('preserves exact buffer lengths and independence across the native cutoff', () => {
+    for (const length of [381, 382, 383, 384, 385, 4095, 4096, 4097]) {
+      const bytes = Uint8Array.from({ length }, (_, i) => i % 256);
+      const json = toJSON(bytes.buffer);
+      const first = fromJSON<ArrayBuffer>(json);
+      const second = fromJSON<ArrayBuffer>(json);
+      expect(first.byteLength).toBe(length);
+      expect(new Uint8Array(first)).toEqual(bytes);
+      new Uint8Array(first).fill(42);
+      expect(new Uint8Array(second)).toEqual(bytes);
+    }
+  });
+});
+
 describe('compact ArrayBuffer views', () => {
   it('preserves backing-buffer identity and offsets by default', () => {
     const buffer = new ArrayBuffer(32);


### PR DESCRIPTION
JSON deserialization copies decoded binary strings into an ArrayBuffer one byte at a time. Use Node's native byte conversion in `fromJSON` and `fromCrossJSON` for base64 strings of at least 512 characters (about 384 decoded bytes). Smaller values keep the existing loop to avoid native conversion overhead.

Keep `atob` validation before conversion because Node's base64 decoder accepts malformed input. Copy the exact byte range out of the Buffer so pooled storage cannot change the returned buffer's length or alias unrelated data. Existing decode limits, shared-view identity, browser fallback, and generated JavaScript remain unchanged.
