### PR TITLE
perf: skip replacement for unescaped strings

### DIFF
--- a/.changeset/fast-unescaped-string-decoding.md
+++ b/.changeset/fast-unescaped-string-decoding.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Skip escape replacement when decoding strings without backslashes.

--- a/packages/seroval/src/core/string.ts
+++ b/packages/seroval/src/core/string.ts
@@ -92,6 +92,9 @@ function deserializeReplacer(str: string): string {
 }
 
 export function deserializeString(str: string): string {
+  if (typeof str === 'string' && !str.includes('\\')) {
+    return str;
+  }
   return str.replace(
     /(\\\\|\\"|\\n|\\r|\\b|\\t|\\f|\\u2028|\\u2029|\\x3C)/g,
     deserializeReplacer,

--- a/packages/seroval/test/string-decoding.test.ts
+++ b/packages/seroval/test/string-decoding.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { fromCrossJSON, fromJSON, toCrossJSON, toJSON } from '../src';
+import { deserializeString, serializeString } from '../src/core/string';
+
+describe('string decoding', () => {
+  it.each([
+    '',
+    'hello',
+    'x'.repeat(4096),
+    'caf\u00e9 \u4e2d\u6587 \ud83d\ude00',
+    '\ud800\udfff\ud800',
+    '\x00\x01\x0b\x1f',
+    '"\\\n\r\b\t\f<\u2028\u2029',
+    '\\n\\u2028\\x3C',
+  ])('round-trips %j through JSON modes', value => {
+    expect(fromJSON(toJSON(value))).toBe(value);
+    expect(fromCrossJSON(toCrossJSON(value), {})).toBe(value);
+  });
+
+  it.each([
+    ['\\n', '\n'],
+    ['\\\\n', '\\n'],
+    ['\\\\\\n', '\\\n'],
+    ['\\x3C\\u2028\\u2029', '<\u2028\u2029'],
+    ['\\x3c\\u0041\\z\\', '\\x3c\\u0041\\z\\'],
+    ['x'.repeat(4096) + '\\n', 'x'.repeat(4096) + '\n'],
+  ])('decodes %j without interpreting additional escapes', (input, output) => {
+    expect(deserializeString(input)).toBe(output);
+  });
+
+  it('preserves every UTF-16 code unit', () => {
+    for (let code = 0; code <= 0xffff; code++) {
+      const value = String.fromCharCode(code);
+      expect(deserializeString(serializeString(value))).toBe(value);
+    }
+  });
+
+  it('decodes mixed property keys and values', () => {
+    const input = {
+      ordinary: 'text',
+      'quote"': 'line\nbreak',
+      'literal\\n': '<script>\u2028',
+      unicode: '\ud800\ud83d\ude00',
+    };
+    expect(fromJSON(toJSON(input))).toEqual(input);
+    expect(fromCrossJSON(toCrossJSON(input), {})).toEqual(input);
+  });
+
+  it('retains replacement behavior for non-primitive inputs', () => {
+    // Some node fields reach the helper without String coercion.
+    const boxed = new Object('hello') as string;
+    expect(deserializeString(boxed)).toBe('hello');
+    const custom = { replace: () => 'replacement' } as unknown as string;
+    expect(deserializeString(custom)).toBe('replacement');
+  });
+});


### PR DESCRIPTION
Skip regex replacement for strings without backslashes, reducing CPU work when decoding ordinary text and object keys through `fromJSON()` and `fromCrossJSON()`. Escaped strings and non-primitive inputs retain the existing decoder, and the serialized format is unchanged.

The tradeoff is an additional scan for escaped strings. A long string with its only escape near the end was about 10% slower in the Firefox fixture.
