### PR TITLE
perf: decode binary data into owned output buffers

### DIFF
--- a/.changeset/owned-binary-output.md
+++ b/.changeset/owned-binary-output.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Write decoded binary data directly into its output ArrayBuffer in Node, avoiding a temporary byte buffer and an additional copy.

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -497,11 +497,9 @@ function deserializeArrayBuffer(
     buffer = ARRAY_BUFFER_CONSTRUCTOR(source);
   } else {
     // Keep atob's validation; Buffer's base64 decoder accepts malformed input.
-    const bytes = Buffer.from(atob(source), 'latin1');
-    buffer = bytes.buffer.slice(
-      bytes.byteOffset,
-      bytes.byteOffset + bytes.byteLength,
-    );
+    const decoded = atob(source);
+    buffer = new ArrayBuffer(decoded.length);
+    Buffer.from(buffer).write(decoded, 'latin1');
   }
   return assignIndexedValue(ctx, node.i, buffer);
 }

--- a/packages/seroval/test/binary.test.ts
+++ b/packages/seroval/test/binary.test.ts
@@ -100,6 +100,29 @@ describe('binary decoding validation', () => {
       expect(new Uint8Array(second)).toEqual(bytes);
     }
   });
+
+  for (const cross of [false, true]) {
+    it(`returns transferable buffers with shared views (cross: ${cross})`, () => {
+      for (const length of [383, 384, 385, 4096, 65536]) {
+        const bytes = Uint8Array.from({ length }, (_, i) => i % 256);
+        const input = {
+          buffer: bytes.buffer,
+          view: new Uint8Array(bytes.buffer),
+        };
+        const back = cross
+          ? fromCrossJSON<typeof input>(toCrossJSON(input), { refs: new Map() })
+          : fromJSON<typeof input>(toJSON(input));
+        expect(back.view.buffer).toBe(back.buffer);
+
+        const transferred = structuredClone(back, { transfer: [back.buffer] });
+        expect(back.buffer.byteLength).toBe(0);
+        expect(back.view.byteLength).toBe(0);
+        expect(transferred.buffer.byteLength).toBe(length);
+        expect(transferred.view.buffer).toBe(transferred.buffer);
+        expect(transferred.view).toEqual(bytes);
+      }
+    });
+  }
 });
 
 describe('compact ArrayBuffer views', () => {


### PR DESCRIPTION
Node binary JSON decoding currently creates a temporary Buffer and copies its bytes into a separate ArrayBuffer. Write directly into a newly allocated ArrayBuffer through a Buffer view, avoiding the temporary byte buffer and the additional copy.

Keep `atob` validation before conversion and preserve exact output lengths, independent ownership, transferability, shared views, and the existing fallback. This follows up on #159.
