### PR TITLE
fix: preserve reserved property names

### DIFF
--- a/.changeset/preserve-reserved-properties.md
+++ b/.changeset/preserve-reserved-properties.md
@@ -3,3 +3,5 @@
 ---
 
 Preserve reserved own property names in cyclic objects and retain Error `__proto__` data properties without changing their prototypes.
+
+Compatibility note: Error `__proto__` fields previously dropped are now preserved as own data properties. Copying these results with `Object.assign({}, value)` can change the destination's prototype. Use `{ ...value }` for shallow copies; later merges still require safe handling.

--- a/.changeset/preserve-reserved-properties.md
+++ b/.changeset/preserve-reserved-properties.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Preserve reserved own property names in cyclic objects and retain Error `__proto__` data properties without changing their prototypes.

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -505,7 +505,7 @@ function createObjectAssign(
   key: string,
   value: string,
 ): void {
-  if (!isValidKey(key)) {
+  if (key === '__proto__') {
     // `obj.__proto__ = x`, including the bracket form `obj["__proto__"] = x`,
     // invokes the prototype setter rather than creating an own property.
     // Define the property instead so the round-trip preserves it as an actual
@@ -821,7 +821,10 @@ function serializeDictionary(
 ): string {
   if (node.p) {
     const base = ctx.base;
-    if (base.features & Feature.ObjectAssign) {
+    if (
+      base.features & Feature.ObjectAssign &&
+      !node.p.k.includes('__proto__')
+    ) {
       init = serializeWithObjectAssign(ctx, node, node.p, init);
     } else {
       markSerializerRef(base, node.i);

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -62,7 +62,6 @@ import type {
 } from '../types';
 import getIdentifier from '../utils/get-identifier';
 import { isValidIdentifier } from '../utils/is-valid-identifier';
-import { isValidKey } from '../utils/valid-properties';
 
 const enum AssignmentType {
   Index = 0,
@@ -628,6 +627,22 @@ function serializeArray(
   return '[]';
 }
 
+const enum PropertyKeyType {
+  Quoted = 0,
+  Numeric = 1,
+  Identifier = 2,
+}
+
+function getPropertyKeyType(key: string): PropertyKeyType {
+  const numeric = Number(key);
+  if (numeric >= 0 && numeric.toString() === key) {
+    return PropertyKeyType.Numeric;
+  }
+  return isValidIdentifier(key)
+    ? PropertyKeyType.Identifier
+    : PropertyKeyType.Quoted;
+}
+
 function serializeProperty(
   ctx: SerializerContext,
   source: SerovalNodeWithProperties,
@@ -635,39 +650,28 @@ function serializeProperty(
   val: SerovalNode,
 ): string {
   if (typeof key === 'string') {
-    const check = Number(key);
-    const isIdentifier =
-      // Test if key is a valid positive number or JS identifier
-      // so that we don't have to serialize the key and wrap with brackets
-      (check >= 0 &&
-        // It's also important to consider that if the key is
-        // indeed numeric, we need to make sure that when
-        // converted back into a string, it's still the same
-        // to the original key. This allows us to differentiate
-        // keys that has numeric formats but in a different
-        // format, which can cause unintentional key declaration
-        // Example: { 0x1: 1 } vs { '0x1': 1 }
-        check.toString() === key) ||
-      isValidIdentifier(key);
+    const keyType = getPropertyKeyType(key);
     if (isIndexedValueInStack(ctx.base, val)) {
       const refParam = getRefParam(ctx, (val as SerovalIndexedValueNode).i);
       markSerializerRef(ctx.base, source.i);
-      // Strict identifier check, make sure
-      // that it isn't numeric (except NaN)
-      if (isIdentifier && check !== check) {
+      if (keyType === PropertyKeyType.Identifier) {
         createObjectAssign(ctx, source.i, key, refParam);
       } else {
         createArrayAssign(
           ctx,
           source.i,
-          isIdentifier ? key : '"' + key + '"',
+          keyType === PropertyKeyType.Quoted ? '"' + key + '"' : key,
           refParam,
         );
       }
       return '';
     }
-    if (isValidKey(key)) {
-      return (isIdentifier ? key : '"' + key + '"') + ':' + serialize(ctx, val);
+    if (key !== '__proto__') {
+      return (
+        (keyType === PropertyKeyType.Quoted ? '"' + key + '"' : key) +
+        ':' +
+        serialize(ctx, val)
+      );
     }
     // `__proto__` as an identifier or string key in an object literal is the
     // prototype setter, not an own property; use a computed key so the
@@ -728,48 +732,22 @@ function serializeStringKeyAssignment(
 ): void {
   const base = ctx.base;
   const serialized = serialize(ctx, value);
-  const check = Number(key);
-  const isIdentifier =
-    // Test if key is a valid positive number or JS identifier
-    // so that we don't have to serialize the key and wrap with brackets
-    (check >= 0 &&
-      // It's also important to consider that if the key is
-      // indeed numeric, we need to make sure that when
-      // converted back into a string, it's still the same
-      // to the original key. This allows us to differentiate
-      // keys that has numeric formats but in a different
-      // format, which can cause unintentional key declaration
-      // Example: { 0x1: 1 } vs { '0x1': 1 }
-      check.toString() === key) ||
-    isValidIdentifier(key);
-  if (isIndexedValueInStack(base, value)) {
-    // Strict identifier check, make sure
-    // that it isn't numeric (except NaN)
-    if (isIdentifier && check !== check) {
-      createObjectAssign(ctx, source.i, key, serialized);
-    } else {
-      createArrayAssign(
-        ctx,
-        source.i,
-        isIdentifier ? key : '"' + key + '"',
-        serialized,
-      );
-    }
-  } else {
-    const parentAssignment = base.assignments;
+  const keyType = getPropertyKeyType(key);
+  const parentAssignment = base.assignments;
+  if (!isIndexedValueInStack(base, value)) {
     base.assignments = mainAssignments;
-    if (isIdentifier && check !== check) {
-      createObjectAssign(ctx, source.i, key, serialized);
-    } else {
-      createArrayAssign(
-        ctx,
-        source.i,
-        isIdentifier ? key : '"' + key + '"',
-        serialized,
-      );
-    }
-    base.assignments = parentAssignment;
   }
+  if (keyType === PropertyKeyType.Identifier) {
+    createObjectAssign(ctx, source.i, key, serialized);
+  } else {
+    createArrayAssign(
+      ctx,
+      source.i,
+      keyType === PropertyKeyType.Quoted ? '"' + key + '"' : key,
+      serialized,
+    );
+  }
+  base.assignments = parentAssignment;
 }
 
 function serializeAssignment(

--- a/packages/seroval/src/core/utils/error.ts
+++ b/packages/seroval/src/core/utils/error.ts
@@ -33,36 +33,24 @@ export function getErrorConstructor(error: ErrorValue): ErrorConstructorTag {
   return ErrorConstructorTag.Error;
 }
 
-function getInitialErrorOptions(error: Error): Record<string, unknown> {
-  const options: Record<string, unknown> = Object.create(null);
-  const construct = ERROR_CONSTRUCTOR_STRING[getErrorConstructor(error)];
-  // Name has been modified
-  if (error.name !== construct) {
-    options.name = error.name;
-  } else if (error.constructor.name !== construct) {
-    // Otherwise, name is overriden because
-    // the Error class is extended
-    options.name = error.constructor.name;
-  }
-  return options;
-}
-
 export function getErrorOptions(
   error: Error,
   features: number,
 ): Record<string, unknown> | undefined {
-  const options = getInitialErrorOptions(error);
-  const names = Object.getOwnPropertyNames(error);
-  for (let i = 0, len = names.length, name: string; i < len; i++) {
-    name = names[i];
-    if (name !== 'name' && name !== 'message') {
-      if (name === 'stack') {
-        if (features & Feature.ErrorPrototypeStack) {
-          options[name] = error[name as keyof Error];
-        }
-      } else {
-        options[name] = error[name as keyof Error];
-      }
+  const options: Record<string, unknown> = Object.create(null);
+  const construct = ERROR_CONSTRUCTOR_STRING[getErrorConstructor(error)];
+  if (error.name !== construct) {
+    options.name = error.name;
+  } else if (error.constructor.name !== construct) {
+    options.name = error.constructor.name;
+  }
+  for (const name of Object.getOwnPropertyNames(error)) {
+    if (
+      name !== 'name' &&
+      name !== 'message' &&
+      (name !== 'stack' || features & Feature.ErrorPrototypeStack)
+    ) {
+      options[name] = error[name as keyof Error];
     }
   }
   return options;

--- a/packages/seroval/src/core/utils/error.ts
+++ b/packages/seroval/src/core/utils/error.ts
@@ -33,38 +33,34 @@ export function getErrorConstructor(error: ErrorValue): ErrorConstructorTag {
   return ErrorConstructorTag.Error;
 }
 
-function getInitialErrorOptions(
-  error: Error,
-): Record<string, unknown> | undefined {
+function getInitialErrorOptions(error: Error): Record<string, unknown> {
+  const options: Record<string, unknown> = Object.create(null);
   const construct = ERROR_CONSTRUCTOR_STRING[getErrorConstructor(error)];
   // Name has been modified
   if (error.name !== construct) {
-    return { name: error.name };
-  }
-  if (error.constructor.name !== construct) {
+    options.name = error.name;
+  } else if (error.constructor.name !== construct) {
     // Otherwise, name is overriden because
     // the Error class is extended
-    return { name: error.constructor.name };
+    options.name = error.constructor.name;
   }
-  return {};
+  return options;
 }
 
 export function getErrorOptions(
   error: Error,
   features: number,
 ): Record<string, unknown> | undefined {
-  let options = getInitialErrorOptions(error);
+  const options = getInitialErrorOptions(error);
   const names = Object.getOwnPropertyNames(error);
   for (let i = 0, len = names.length, name: string; i < len; i++) {
     name = names[i];
     if (name !== 'name' && name !== 'message') {
       if (name === 'stack') {
         if (features & Feature.ErrorPrototypeStack) {
-          options = options || {};
           options[name] = error[name as keyof Error];
         }
       } else {
-        options = options || {};
         options[name] = error[name as keyof Error];
       }
     }

--- a/packages/seroval/test/error.test.ts
+++ b/packages/seroval/test/error.test.ts
@@ -3,6 +3,9 @@ import {
   crossSerialize,
   crossSerializeAsync,
   crossSerializeStream,
+  deserialize,
+  Feature,
+  fromJSON,
   serialize,
   serializeAsync,
   toCrossJSON,
@@ -13,6 +16,51 @@ import {
 } from '../src';
 
 describe('Error', () => {
+  describe('with an own __proto__ field', () => {
+    function makeError(): Error {
+      const error = new Error('field');
+      Object.defineProperty(error, '__proto__', {
+        value: { retained: true },
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      return error;
+    }
+
+    function expectPreserved(back: Error): void {
+      expect(Object.getPrototypeOf(back)).toBe(Error.prototype);
+      expect(Object.getOwnPropertyDescriptor(back, '__proto__')).toEqual({
+        value: { retained: true },
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      expect(back.message).toBe('field');
+    }
+
+    it.each([0, Feature.ObjectAssign])(
+      'preserves the field through serialize with disabled features %i',
+      disabledFeatures => {
+        expectPreserved(
+          deserialize(serialize(makeError(), { disabledFeatures })),
+        );
+      },
+    );
+
+    it('preserves the field through serializeAsync', async () => {
+      expectPreserved(deserialize(await serializeAsync(makeError())));
+    });
+
+    it('preserves the field through JSON', () => {
+      expectPreserved(fromJSON(toJSON(makeError())));
+    });
+
+    it('preserves the field through crossSerialize', () => {
+      const payload = crossSerialize(makeError());
+      expectPreserved(new Function('$R', `return (${payload})`)([]));
+    });
+  });
   describe('serialize', () => {
     it('supports Error.prototype.name', () => {
       const a = new Error('A');

--- a/packages/seroval/test/object.test.ts
+++ b/packages/seroval/test/object.test.ts
@@ -666,6 +666,28 @@ describe('objects', () => {
       expectPreserved(new Function('$R', `return (${payload})`)([]));
     });
   });
+  it.each([
+    '',
+    '0',
+    '-0',
+    '01',
+    '1.5',
+    '1e3',
+    '1e+21',
+    'Infinity',
+    'NaN',
+    '1e400',
+    'needs-quote',
+  ])('preserves property spelling %j in deferred assignments', key => {
+    const source: Record<string, unknown> = {};
+    source[key] = source;
+    for (const payload of [serialize(source), compileJSON(toJSON(source))]) {
+      const back = deserialize<Record<string, unknown>>(payload);
+      expect(Object.keys(back)).toEqual([key]);
+      expect(back[key]).toBe(back);
+      expect(Object.getPrototypeOf(back)).toBe(Object.prototype);
+    }
+  });
   describe('with a shadowed constructor property', () => {
     const SHADOWED = { constructor: 'not a constructor', value: 42 };
 

--- a/packages/seroval/test/object.test.ts
+++ b/packages/seroval/test/object.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  Feature,
   compileJSON,
   crossSerialize,
   crossSerializeAsync,
   crossSerializeStream,
   deserialize,
+  Feature,
   fromCrossJSON,
   fromJSON,
   serialize,
@@ -540,7 +540,10 @@ describe('objects', () => {
     // `JSON.parse` creates an own enumerable `__proto__` data property
     // (not a prototype), as does any record with a `__proto__` field.
     function makeProtoObject(): Record<string, unknown> {
-      return JSON.parse('{"__proto__":5,"value":42}') as Record<string, unknown>;
+      return JSON.parse('{"__proto__":5,"value":42}') as Record<
+        string,
+        unknown
+      >;
     }
     function expectPreserved(back: Record<string, unknown>): void {
       const descriptor = Object.getOwnPropertyDescriptor(back, '__proto__');
@@ -611,6 +614,56 @@ describe('objects', () => {
       expectPreserved(
         fromJSON<Record<string, unknown>>(toJSON(makeCircularProtoObject())),
       );
+    });
+  });
+  describe.each([
+    'constructor',
+    'prototype',
+    '__proto__',
+    '__defineGetter__',
+    '__defineSetter__',
+    '__lookupGetter__',
+    '__lookupSetter__',
+  ])('with a circular reserved property %s', key => {
+    function makeCircularObject(): Record<string, unknown> {
+      const parent: Record<string, unknown> = {};
+      const child = {};
+      parent.child = child;
+      Object.defineProperty(child, key, {
+        value: parent,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      return parent;
+    }
+
+    function expectPreserved(back: Record<string, unknown>): void {
+      const child = back.child as Record<string, unknown>;
+      expect(Object.getOwnPropertyDescriptor(child, key)).toEqual({
+        value: back,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      expect(Object.getPrototypeOf(child)).toBe(Object.prototype);
+    }
+
+    it('preserves the key through serialize', () => {
+      expectPreserved(deserialize(serialize(makeCircularObject())));
+    });
+
+    it('preserves the key through serializeAsync', async () => {
+      expectPreserved(deserialize(await serializeAsync(makeCircularObject())));
+    });
+
+    it('preserves the key through compileJSON', () => {
+      expectPreserved(deserialize(compileJSON(toJSON(makeCircularObject()))));
+    });
+
+    it('preserves the key through crossSerialize', () => {
+      const payload = crossSerialize(makeCircularObject());
+      expectPreserved(new Function('$R', `return (${payload})`)([]));
     });
   });
   describe('with a shadowed constructor property', () => {


### PR DESCRIPTION
Preserve circular own properties such as `constructor` and `prototype` instead of writing them as `__proto__`. Keep Error `__proto__` fields as own data properties without changing the Error prototype, including when `Object.assign` is disabled.

Share property-key classification, deferred assignment emission, and Error field collection.

Minified ESM with esbuild 0.28.2, ES2020, gzip level 9 and Brotli quality 11, compared with upstream `d675645`:

| Import | Gzip before | Gzip after | Brotli before | Brotli after |
| --- | ---: | ---: | ---: | ---: |
| Full export set | 12,462 B | 12,445 B | 11,183 B | 11,174 B |
| `serialize` | 8,533 B | 8,472 B | 7,694 B | 7,625 B |
| `toJSONAsync` + `fromCrossJSON` | 6,950 B | 6,930 B | 6,262 B | 6,236 B |

Compatibility note: Error `__proto__` fields previously dropped are now preserved as own data properties. Copying these results with `Object.assign({}, value)` can change the destination's prototype. Use `{ ...value }` for shallow copies; later merges still require safe handling.