### PR TITLE
fix: bound and preserve deferred assignment chains

### DIFF
--- a/.changeset/bounded-assignment-chains.md
+++ b/.changeset/bounded-assignment-chains.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Preserve cyclic Map entries when deferred assignments remove placeholders, and bound generated assignment chains so large graphs can be evaluated.

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -144,16 +144,27 @@ function getAssignmentExpression(assignment: Assignment): string {
   }
 }
 
+const MAX_ASSIGNMENT_CHAIN_LENGTH = 100;
+
 function mergeAssignments(assignments: Assignment[]): Assignment[] {
   const newAssignments: Assignment[] = [];
   let current = assignments[0];
+  let chainLength = 1;
   for (
     let i = 1, len = assignments.length, item: Assignment, prev = current;
     i < len;
     i++
   ) {
     item = assignments[i];
-    if (item.t === AssignmentType.Index && item.v === prev.v) {
+    if (chainLength === MAX_ASSIGNMENT_CHAIN_LENGTH) {
+      newAssignments.push(current);
+      current = item;
+      chainLength = 0;
+    } else if (
+      item.t === AssignmentType.Index &&
+      prev.t === AssignmentType.Index &&
+      item.v === prev.v
+    ) {
       // Merge if the right-hand value is the same
       // saves at least 2 chars
       current = {
@@ -162,7 +173,11 @@ function mergeAssignments(assignments: Assignment[]): Assignment[] {
         k: NIL,
         v: getAssignmentExpression(current),
       } as IndexAssignment;
-    } else if (item.t === AssignmentType.Set && item.s === prev.s) {
+    } else if (
+      item.t === AssignmentType.Set &&
+      prev.t === AssignmentType.Set &&
+      item.s === prev.s
+    ) {
       // Maps has chaining methods, merge if source is the same
       current = {
         t: AssignmentType.Set,
@@ -170,7 +185,11 @@ function mergeAssignments(assignments: Assignment[]): Assignment[] {
         k: item.k,
         v: item.v,
       } as SetAssignment;
-    } else if (item.t === AssignmentType.Add && item.s === prev.s) {
+    } else if (
+      item.t === AssignmentType.Add &&
+      prev.t === AssignmentType.Add &&
+      item.s === prev.s
+    ) {
       // Sets has chaining methods too
       current = {
         t: AssignmentType.Add,
@@ -178,8 +197,11 @@ function mergeAssignments(assignments: Assignment[]): Assignment[] {
         k: NIL,
         v: item.v,
       } as AddAssignment;
-    } else if (item.t === AssignmentType.Delete && item.s === prev.s) {
-      // Maps has chaining methods, merge if source is the same
+    } else if (
+      item.t === AssignmentType.Delete &&
+      prev.t === AssignmentType.Set &&
+      item.s === prev.s
+    ) {
       current = {
         t: AssignmentType.Delete,
         s: getAssignmentExpression(current),
@@ -190,7 +212,9 @@ function mergeAssignments(assignments: Assignment[]): Assignment[] {
       // Different assignment, push current
       newAssignments.push(current);
       current = item;
+      chainLength = 0;
     }
+    chainLength++;
     prev = item;
   }
 

--- a/packages/seroval/test/map.test.ts
+++ b/packages/seroval/test/map.test.ts
@@ -29,6 +29,42 @@ ASYNC_RECURSIVE.set(
 );
 
 describe('Map', () => {
+  describe.each([
+    ['serialize', serialize],
+    ['serializeAsync', serializeAsync],
+    ['crossSerialize', crossSerialize],
+    ['crossSerializeAsync', crossSerializeAsync],
+  ])('%s deferred assignments', (_name, encode) => {
+    it.each(['keys', 'values'])(
+      'preserves ancestor %s and repeated objects',
+      async side => {
+        const source = {
+          inner: { map: new Map<unknown, unknown>() },
+          first: { name: 'first' },
+          second: { name: 'second' },
+        };
+        if (side === 'keys') {
+          source.inner.map.set(source, source.first);
+          source.inner.map.set(source.inner, source.second);
+        } else {
+          source.inner.map.set(source.first, source);
+          source.inner.map.set(source.second, source.inner);
+        }
+        const payload = await encode(source);
+        const back = new Function('$R', `return (${payload})`)(
+          [],
+        ) as typeof source;
+        expect(back.inner.map.size).toBe(2);
+        if (side === 'keys') {
+          expect(back.inner.map.get(back)).toBe(back.first);
+          expect(back.inner.map.get(back.inner)).toBe(back.second);
+        } else {
+          expect(back.inner.map.get(back.first)).toBe(back);
+          expect(back.inner.map.get(back.second)).toBe(back.inner);
+        }
+      },
+    );
+  });
   describe('serialize', () => {
     it('supports Map', () => {
       const result = serialize(EXAMPLE);

--- a/packages/seroval/test/mutual-cycle.test.ts
+++ b/packages/seroval/test/mutual-cycle.test.ts
@@ -16,6 +16,33 @@ import {
 } from '../src';
 
 describe('mutual cyclic references', () => {
+  describe.each([
+    ['serialize', serialize],
+    ['serializeAsync', serializeAsync],
+    ['crossSerialize', crossSerialize],
+    ['crossSerializeAsync', crossSerializeAsync],
+  ])('%s deferred assignments', (_name, encode) => {
+    it('evaluates a large graph of repeated back-references', async () => {
+      const source: { items: Record<string, unknown>[] } = { items: [] };
+      for (let index = 0; index < 3000; index++) {
+        source.items.push({
+          owner: source,
+          alternate: source,
+          repeated: source,
+        });
+      }
+      const payload = await encode(source);
+      const back = new Function('$R', `return (${payload})`)(
+        [],
+      ) as typeof source;
+      expect(back.items.length).toBe(source.items.length);
+      for (const item of back.items) {
+        expect(item.owner).toBe(back);
+        expect(item.alternate).toBe(back);
+        expect(item.repeated).toBe(back);
+      }
+    });
+  });
   describe('serialize', () => {
     it('supports Arrays and Arrays', () => {
       const a: unknown[] = [];


### PR DESCRIPTION
Stop chaining Map operations after `.delete()`, which returns a boolean, and merge only compatible deferred assignments.

Limit each generated chain to 100 assignments so large cyclic graphs remain evaluable without overflowing the JavaScript parser.