### PR TITLE
fix: release completed stream parser state

### DIFF
--- a/.changeset/release-stream-parser-state.md
+++ b/.changeset/release-stream-parser-state.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Release stream parser subscriptions and buffered nodes after use, and complete serialization once after buffered chunks are emitted.

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -445,34 +445,36 @@ function parseStream(
     return result;
   }
   pushPendingState(ctx);
-  current.on({
-    next: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamNextNode(id, parsed));
+  ctx.state.cleanups.push(
+    current.on({
+      next: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamNextNode(id, parsed));
+          }
         }
-      }
-    },
-    throw: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamThrowNode(id, parsed));
+      },
+      throw: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamThrowNode(id, parsed));
+          }
         }
-      }
-      popPendingState(ctx);
-    },
-    return: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamReturnNode(id, parsed));
+        popPendingState(ctx);
+      },
+      return: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamReturnNode(id, parsed));
+          }
         }
-      }
-      popPendingState(ctx);
-    },
-  });
+        popPendingState(ctx);
+      },
+    }),
+  );
   return result;
 }
 
@@ -932,16 +934,6 @@ function onError(ctx: StreamParserContext, error: unknown): void {
   }
 }
 
-function onDone(ctx: StreamParserContext): void {
-  if (ctx.state.onDone) {
-    ctx.state.onDone();
-  }
-
-  for (let i = 0, len = ctx.state.cleanups.length; i < len; i++) {
-    ctx.state.cleanups[i]();
-  }
-}
-
 function onParseInternal(
   ctx: StreamParserContext,
   node: SerovalNode,
@@ -959,8 +951,8 @@ function pushPendingState(ctx: StreamParserContext): void {
 }
 
 function popPendingState(ctx: StreamParserContext): void {
-  if (--ctx.state.pending <= 0) {
-    onDone(ctx);
+  if (--ctx.state.pending <= 0 && !ctx.state.initial) {
+    destroyStreamParse(ctx);
   }
 }
 
@@ -998,14 +990,37 @@ function flushStreamParse(
   ctx: StreamParserContext,
   state: StreamParserState,
 ): void {
-  for (let i = 0, len = state.buffer.length; i < len; i++) {
-    onParseInternal(ctx, state.buffer[i], false);
+  try {
+    for (
+      let index = 0, length = state.buffer.length;
+      index < length && state.alive;
+      index++
+    ) {
+      onParseInternal(ctx, state.buffer[index], false);
+    }
+  } finally {
+    state.buffer.length = 0;
   }
 }
 
 export function destroyStreamParse(ctx: StreamParserContext): void {
-  if (ctx.state.alive) {
-    onDone(ctx);
-    ctx.state.alive = false;
+  const state = ctx.state;
+  if (state.alive) {
+    state.alive = false;
+    try {
+      if (state.onDone) {
+        state.onDone();
+      }
+    } finally {
+      for (
+        let index = 0, length = state.cleanups.length;
+        index < length;
+        index++
+      ) {
+        state.cleanups[index]();
+      }
+      state.cleanups.length = 0;
+      state.buffer.length = 0;
+    }
   }
 }

--- a/packages/seroval/test/stream-cancellation.test.ts
+++ b/packages/seroval/test/stream-cancellation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { crossSerializeStream, toCrossJSONStream } from '../src';
+import { createStream, crossSerializeStream, toCrossJSONStream } from '../src';
 
 const serializers = [
   [
@@ -13,6 +13,57 @@ const serializers = [
       crossSerializeStream(value, { onSerialize: emit }),
   ],
 ] as const;
+
+describe.each(serializers)('%s stream subscriptions', (name, serialize) => {
+  it.each(['cancel', 'return', 'throw'] as const)(
+    'releases its subscription after %s',
+    mode => {
+      const source = createStream<number>();
+      const subscribe = source.on;
+      let subscribed = false;
+      source.on = listener => {
+        subscribed = true;
+        const unsubscribe = subscribe(listener);
+        return () => {
+          subscribed = false;
+          unsubscribe();
+        };
+      };
+      const emit = vi.fn();
+      const cancel = serialize(source, emit);
+      expect(subscribed).toBe(true);
+      if (mode === 'cancel') {
+        cancel();
+      } else {
+        source[mode](1);
+      }
+      expect(subscribed).toBe(false);
+      emit.mockClear();
+      source.next(2);
+      expect(emit).not.toHaveBeenCalled();
+    },
+  );
+
+  it('completes once when the completion callback cancels serialization', () => {
+    const source = createStream<number>();
+    let completions = 0;
+    const options = {
+      onParse: vi.fn(),
+      onSerialize: vi.fn(),
+      onDone() {
+        completions++;
+        cancel();
+      },
+    };
+    const cancel =
+      name === 'JSON'
+        ? toCrossJSONStream(source, options)
+        : crossSerializeStream(source, options);
+    source.return(1);
+    cancel();
+    expect(completions).toBe(1);
+  });
+});
 
 describe.each(serializers)(
   '%s async iterator cancellation',

--- a/packages/seroval/test/stream-draining.test.ts
+++ b/packages/seroval/test/stream-draining.test.ts
@@ -1,7 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { fromCrossJSON, toCrossJSONStream } from '../src';
+import { createStream, fromCrossJSON, toCrossJSONStream } from '../src';
 
 describe('long async iterable streams', () => {
+  it('emits buffered chunks before completing once', () => {
+    const source = createStream<number>();
+    source.next(1);
+    source.return(2);
+    const events: string[] = [];
+    const refs = new Map();
+    let restored: ReturnType<typeof createStream<number>> | undefined;
+    const cancel = toCrossJSONStream(source, {
+      onParse(node, initial) {
+        const value = fromCrossJSON<ReturnType<typeof createStream<number>>>(
+          node,
+          { refs },
+        );
+        if (initial) {
+          restored = value;
+        }
+        events.push(initial ? 'initial' : 'chunk');
+      },
+      onDone() {
+        events.push('done');
+      },
+    });
+    cancel();
+    expect(events).toEqual(['initial', 'chunk', 'chunk', 'done']);
+    const values: number[] = [];
+    restored?.on({
+      next(value) {
+        values.push(value);
+      },
+      return(value) {
+        values.push(value);
+      },
+      throw(error) {
+        throw error;
+      },
+    });
+    expect(values).toEqual([1, 2]);
+  });
+
   it.each(['return', 'throw'])('preserves chunk order and %s', async mode => {
     async function* source() {
       await Promise.resolve();


### PR DESCRIPTION
Release subscriptions on cancellation and completion, clear replayed nodes, and notify completion once after buffered chunks are emitted. Reentrant cancellation no longer repeats completion.

For a 1,000-item replay on Node 24.12.0, emitted nodes retained after replay fell from 1,000 to 0 after garbage collection, compared with `7294565`.