### PR TITLE
perf: allow unused iterator factories to be removed

### DIFF
--- a/.changeset/tree-shake-iterator-factories.md
+++ b/.changeset/tree-shake-iterator-factories.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Allow bundlers to remove unused iterator factories from consumers that do not need deserialization.

--- a/packages/seroval/src/core/sequence.ts
+++ b/packages/seroval/src/core/sequence.ts
@@ -50,7 +50,7 @@ export function createSequenceFromIterable<T>(source: Iterable<T>): Sequence {
   return createSequence(values, throwsAt, doneAt);
 }
 
-const createIterator = ITERATOR_CONSTRUCTOR(SYM_ITERATOR);
+const createIterator = /* @__PURE__ */ ITERATOR_CONSTRUCTOR(SYM_ITERATOR);
 
 export function sequenceToIterator<T>(
   sequence: Sequence,

--- a/packages/seroval/src/core/stream.ts
+++ b/packages/seroval/src/core/stream.ts
@@ -79,7 +79,7 @@ export function createStreamFromAsyncIterable<T>(
   return stream;
 }
 
-const createAsyncIterable = ASYNC_ITERATOR_CONSTRUCTOR(
+const createAsyncIterable = /* @__PURE__ */ ASYNC_ITERATOR_CONSTRUCTOR(
   SYM_ASYNC_ITERATOR,
   PROMISE_CONSTRUCTOR,
 );


### PR DESCRIPTION
Mark the synchronous and asynchronous iterator factory setup calls as pure so unused factories can be removed from consumer bundles.

Minified ESM imports with esbuild 0.28.2, ES2020, gzip level 9, compared with `7294565`:

| Import | Before | After | Saved |
| --- | ---: | ---: | ---: |
| `toJSON` | 5,027 B | 4,689 B | 338 B |
| `deserialize` | 877 B | 494 B | 383 B |
| `createStream` | 1,118 B | 773 B | 345 B |

The full export bundle is unchanged.