### PR TITLE
perf: return reference nodes without temporary wrappers

### DIFF
--- a/.changeset/direct-reference-results.md
+++ b/.changeset/direct-reference-results.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Avoid temporary reference lookup wrappers in the parsers and resolve named references with one registry lookup.

--- a/packages/seroval/src/core/base-primitives.ts
+++ b/packages/seroval/src/core/base-primitives.ts
@@ -12,7 +12,6 @@ import {
   NEG_ZERO_NODE,
 } from './literals';
 import { createSerovalNode } from './node';
-import { getReferenceID } from './reference';
 import { serializeString } from './string';
 import type {
   SerovalAggregateErrorNode,
@@ -139,7 +138,7 @@ export function createDateNode(id: number, current: Date): SerovalDateNode {
   return createSerovalNode(
     SerovalNodeType.Date,
     id,
-    timestamp !== timestamp ? '' : current.toISOString(),
+    timestamp === timestamp ? current.toISOString() : '',
     NIL,
     NIL,
     NIL,
@@ -223,14 +222,14 @@ export function createWKSymbolNode(
   );
 }
 
-export function createReferenceNode<T>(
+export function createReferenceNode(
   id: number,
-  ref: T,
+  referenceId: string,
 ): SerovalReferenceNode {
   return createSerovalNode(
     SerovalNodeType.Reference,
     id,
-    serializeString(getReferenceID(ref)),
+    serializeString(referenceId),
     NIL,
     NIL,
     NIL,

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -84,7 +84,6 @@ import {
   getArrayBufferView,
   getReferenceNode,
   markParserRef,
-  ParserNodeType,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
   parseSpecialReference,
@@ -676,10 +675,10 @@ export async function parseFunctionAsync(
   current: unknown,
 ): Promise<SerovalNode> {
   const ref = getReferenceNode(ctx.base, current);
-  if (ref.type !== ParserNodeType.Fresh) {
-    return ref.value;
+  if (typeof ref !== 'number') {
+    return ref;
   }
-  const plugin = await parsePlugin(ctx, depth, ref.value, current);
+  const plugin = await parsePlugin(ctx, depth, ref, current);
   if (plugin) {
     return plugin;
   }
@@ -708,9 +707,9 @@ export async function parseAsync<T>(
     case 'object': {
       if (current) {
         const ref = getReferenceNode(ctx.base, current);
-        return ref.type === 0
-          ? await parseObjectAsync(ctx, depth + 1, ref.value, current as object)
-          : ref.value;
+        return typeof ref === 'number'
+          ? await parseObjectAsync(ctx, depth + 1, ref, current as object)
+          : ref;
       }
       return NULL_NODE;
     }

--- a/packages/seroval/src/core/context/parser.ts
+++ b/packages/seroval/src/core/context/parser.ts
@@ -9,7 +9,7 @@ import { INV_SYMBOL_REF, NIL, SerovalNodeType } from '../constants';
 import { SerovalUnsupportedTypeError } from '../errors';
 import { createSerovalNode } from '../node';
 import type { PluginAccessOptions, SerovalMode } from '../plugin';
-import { hasReferenceID } from '../reference';
+import { getReferenceID } from '../reference';
 import {
   ASYNC_ITERATOR,
   ITERATOR,
@@ -41,29 +41,6 @@ export interface BaseParserContextOptions extends PluginAccessOptions {
   /** Copy each typed array or DataView's visible bytes into its own buffer. */
   compactArrayBufferViews?: boolean;
 }
-
-export const enum ParserNodeType {
-  Fresh = 0,
-  Indexed = 1,
-  Referenced = 2,
-}
-
-export interface FreshNode {
-  type: ParserNodeType.Fresh;
-  value: number;
-}
-
-export interface IndexedNode {
-  type: ParserNodeType.Indexed;
-  value: SerovalIndexedValueNode;
-}
-
-export interface ReferencedNode {
-  type: ParserNodeType.Referenced;
-  value: SerovalReferenceNode;
-}
-
-type ObjectNode = FreshNode | IndexedNode | ReferencedNode;
 
 export interface BaseParserContext extends PluginAccessOptions {
   readonly mode: SerovalMode;
@@ -123,37 +100,27 @@ export function createIndexForValue<T>(
 export function getNodeForIndexedValue<T>(
   ctx: BaseParserContext,
   current: T,
-): FreshNode | IndexedNode {
+): number | SerovalIndexedValueNode {
   const registeredId = ctx.refs.get(current);
   if (registeredId != null) {
     markParserRef(ctx, registeredId);
-    return {
-      type: ParserNodeType.Indexed,
-      value: createIndexedValueNode(registeredId),
-    };
+    return createIndexedValueNode(registeredId);
   }
-  return {
-    type: ParserNodeType.Fresh,
-    value: createIndexForValue(ctx, current),
-  };
+  return createIndexForValue(ctx, current);
 }
 
 export function getReferenceNode<T>(
   ctx: BaseParserContext,
   current: T,
-): ObjectNode {
+): number | SerovalIndexedValueNode | SerovalReferenceNode {
   const indexed = getNodeForIndexedValue(ctx, current);
-  if (indexed.type === ParserNodeType.Indexed) {
+  if (typeof indexed !== 'number') {
     return indexed;
   }
-  // Special references are special ;)
-  if (hasReferenceID(current)) {
-    return {
-      type: ParserNodeType.Referenced,
-      value: createReferenceNode(indexed.value, current),
-    };
-  }
-  return indexed;
+  const referenceId = getReferenceID(current);
+  return referenceId === undefined
+    ? indexed
+    : createReferenceNode(indexed, referenceId);
 }
 
 /**
@@ -164,11 +131,11 @@ export function parseWellKnownSymbol(
   current: symbol,
 ): SerovalIndexedValueNode | SerovalWKSymbolNode | SerovalReferenceNode {
   const ref = getReferenceNode(ctx, current);
-  if (ref.type !== ParserNodeType.Fresh) {
-    return ref.value;
+  if (typeof ref !== 'number') {
+    return ref;
   }
   if (current in INV_SYMBOL_REF) {
-    return createWKSymbolNode(ref.value, current as WellKnownSymbols);
+    return createWKSymbolNode(ref, current as WellKnownSymbols);
   }
   throw new SerovalUnsupportedTypeError(current);
 }
@@ -178,12 +145,12 @@ export function parseSpecialReference(
   ref: SpecialReference,
 ): SerovalIndexedValueNode | SerovalSpecialReferenceNode {
   const result = getNodeForIndexedValue(ctx, SPECIAL_REFS[ref]);
-  if (result.type === ParserNodeType.Indexed) {
-    return result.value;
+  if (typeof result !== 'number') {
+    return result;
   }
   return createSerovalNode(
     SerovalNodeType.SpecialReference,
-    result.value,
+    result,
     ref,
     NIL,
     NIL,
@@ -201,12 +168,12 @@ export function parseIteratorFactory(
   ctx: BaseParserContext,
 ): SerovalIndexedValueNode | SerovalIteratorFactoryNode {
   const result = getNodeForIndexedValue(ctx, ITERATOR);
-  if (result.type === ParserNodeType.Indexed) {
-    return result.value;
+  if (typeof result !== 'number') {
+    return result;
   }
   return createSerovalNode(
     SerovalNodeType.IteratorFactory,
-    result.value,
+    result,
     NIL,
     NIL,
     NIL,
@@ -224,12 +191,12 @@ export function parseAsyncIteratorFactory(
   ctx: BaseParserContext,
 ): SerovalIndexedValueNode | SerovalAsyncIteratorFactoryNode {
   const result = getNodeForIndexedValue(ctx, ASYNC_ITERATOR);
-  if (result.type === ParserNodeType.Indexed) {
-    return result.value;
+  if (typeof result !== 'number') {
+    return result;
   }
   return createSerovalNode(
     SerovalNodeType.AsyncIteratorFactory,
-    result.value,
+    result,
     NIL,
     NIL,
     NIL,

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -87,7 +87,6 @@ import {
   createPromiseConstructorNode,
   getArrayBufferView,
   getReferenceNode,
-  ParserNodeType,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
   parseSpecialReference,
@@ -854,10 +853,10 @@ function parseFunction(
   current: unknown,
 ): SerovalNode {
   const ref = getReferenceNode(ctx.base, current);
-  if (ref.type !== ParserNodeType.Fresh) {
-    return ref.value;
+  if (typeof ref !== 'number') {
+    return ref;
   }
-  const plugin = parsePlugin(ctx, depth, ref.value, current);
+  const plugin = parsePlugin(ctx, depth, ref, current);
   if (plugin) {
     return plugin;
   }
@@ -886,9 +885,9 @@ export function parseSOS<T>(
     case 'object': {
       if (current) {
         const ref = getReferenceNode(ctx.base, current);
-        return ref.type === ParserNodeType.Fresh
-          ? parseObject(ctx, depth + 1, ref.value, current as object)
-          : ref.value;
+        return typeof ref === 'number'
+          ? parseObject(ctx, depth + 1, ref, current as object)
+          : ref;
       }
       return NULL_NODE;
     }

--- a/packages/seroval/src/core/reference.ts
+++ b/packages/seroval/src/core/reference.ts
@@ -1,7 +1,4 @@
-import {
-  SerovalMissingReferenceError,
-  SerovalMissingReferenceForIdError,
-} from '..';
+import { SerovalMissingReferenceForIdError } from '..';
 import { REFERENCES_KEY } from './keys';
 
 const REFERENCE = new Map<unknown, string>();
@@ -13,19 +10,12 @@ export function createReference<T>(id: string, value: T): T {
   return value;
 }
 
-export function hasReferenceID<T>(value: T): boolean {
-  return REFERENCE.has(value);
-}
-
 export function hasReference(id: string): boolean {
   return INV_REFERENCE.has(id);
 }
 
-export function getReferenceID<T>(value: T): string {
-  if (hasReferenceID(value)) {
-    return REFERENCE.get(value)!;
-  }
-  throw new SerovalMissingReferenceError(value);
+export function getReferenceID(value: unknown): string | undefined {
+  return REFERENCE.get(value);
 }
 
 export function getReference<T>(id: string): T {

--- a/packages/seroval/test/reference.test.ts
+++ b/packages/seroval/test/reference.test.ts
@@ -19,6 +19,34 @@ import {
 const EXAMPLE = createReference('example', () => 'Hello World');
 
 describe('Reference', () => {
+  it.each(['', '0', 'quote"\\\n'])(
+    'preserves the reference name %j',
+    async id => {
+      const reference = createReference(id, { value: 1 });
+      const source = { first: reference, second: reference };
+      const results = [
+        deserialize<typeof source>(serialize(source)),
+        deserialize<typeof source>(await serializeAsync(source)),
+        fromJSON<typeof source>(toJSON(source)),
+        fromJSON<typeof source>(await toJSONAsync(source)),
+      ];
+      for (const result of results) {
+        expect(result.first).toBe(reference);
+        expect(result.second).toBe(reference);
+      }
+    },
+  );
+
+  it('preserves an existing cross reference with ID zero', () => {
+    const value = { value: 1 };
+    const node = toCrossJSON(value, {
+      refs: new Map<unknown, number>([[value, 0]]),
+    });
+    expect(
+      fromCrossJSON(node, { refs: new Map<number, unknown>([[0, value]]) }),
+    ).toBe(value);
+  });
+
   describe('serialize', () => {
     it('supports Reference', () => {
       const result = serialize(EXAMPLE);


### PR DESCRIPTION
Return new reference IDs and existing nodes directly instead of allocating `{ type, value }` wrappers on each parser visit. Resolve named references with one registry lookup instead of repeated presence checks.

Compared with `7294565`, minified ESM with esbuild 0.28.2, ES2020 and gzip level 9:

| Import | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Full export set | 12,511 B | 12,462 B | 49 B |
| `toJSONAsync` + `fromCrossJSON` | 7,003 B | 6,950 B | 53 B |

On Node 24.12.0, `toJSON` of 1,000 named references took a median 0.0891 ms before and 0.0781 ms after, across seven alternating samples of 100 calls. This is a local workload measurement, not a full-application benchmark.