### PR TITLE
perf: skip unnecessary plugin deduplication sets

### DIFF
--- a/.changeset/skip-trivial-plugin-deduplication.md
+++ b/.changeset/skip-trivial-plugin-deduplication.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Skip temporary deduplication sets for empty plugin lists and single plugins without dependencies while preserving independent result arrays.

--- a/packages/seroval/src/core/plugin.ts
+++ b/packages/seroval/src/core/plugin.ts
@@ -97,6 +97,15 @@ export function resolvePlugins(
   plugins?: Plugin<any, any>[],
 ): Plugin<any, any>[] | undefined {
   if (plugins) {
+    if (plugins.length < 2) {
+      if (plugins.length === 0) {
+        return [];
+      }
+      const plugin = plugins[0];
+      if (!plugin.extends || plugin.extends.length === 0) {
+        return [plugin];
+      }
+    }
     const deduped = new Set<Plugin<any, any>>();
     dedupePlugins(deduped, plugins);
     return [...deduped];

--- a/packages/seroval/test/plugin.test.ts
+++ b/packages/seroval/test/plugin.test.ts
@@ -8,6 +8,7 @@ import {
   deserialize,
   fromCrossJSON,
   fromJSON,
+  resolvePlugins,
   serialize,
   serializeAsync,
   toCrossJSON,
@@ -44,6 +45,51 @@ const BufferPlugin = createPlugin<Buffer, SerovalNode>({
 const EXAMPLE = Buffer.from('Hello, World!', 'utf-8');
 
 describe('Plugin', () => {
+  describe('resolution', () => {
+    it('keeps the input list independent of the resolved result', () => {
+      const plugins = [BufferPlugin];
+      const resolved = resolvePlugins(plugins);
+      expect(resolved).toEqual([BufferPlugin]);
+      resolved?.pop();
+      expect(plugins).toEqual([BufferPlugin]);
+      expect(resolvePlugins(plugins)).toEqual([BufferPlugin]);
+    });
+
+    it('keeps empty input lists independent of the resolved result', () => {
+      const plugins: (typeof BufferPlugin)[] = [];
+      const resolved = resolvePlugins(plugins);
+      expect(resolved).toEqual([]);
+      resolved?.push(BufferPlugin);
+      expect(plugins).toEqual([]);
+      expect(resolvePlugins()).toBeUndefined();
+    });
+
+    it('preserves dependency order and removes repeated plugin instances', () => {
+      const parent = createPlugin({
+        ...BufferPlugin,
+        tag: 'parent',
+        extends: [BufferPlugin],
+      });
+      const sibling = createPlugin({ ...BufferPlugin, tag: 'sibling' });
+      expect(resolvePlugins([parent, sibling, BufferPlugin, parent])).toEqual([
+        parent,
+        BufferPlugin,
+        sibling,
+      ]);
+    });
+
+    it('observes dependencies added between resolutions and handles cycles', () => {
+      const dependencies: (typeof BufferPlugin)[] = [];
+      const parent = createPlugin({
+        ...BufferPlugin,
+        tag: 'parent',
+        extends: dependencies,
+      });
+      expect(resolvePlugins([parent])).toEqual([parent]);
+      dependencies.push(BufferPlugin, parent);
+      expect(resolvePlugins([parent])).toEqual([parent, BufferPlugin]);
+    });
+  });
   describe('serialize', () => {
     it('supports Plugin', () => {
       const result = serialize(EXAMPLE, {


### PR DESCRIPTION
Avoid temporary deduplication sets for empty plugin lists and single plugins without dependencies. Keep fresh result arrays and observe dependency changes on later calls.

Median time for 1,000 scalar `Serializer.write` calls on Node 24.12.0, compared with `7294565`, across nine alternating samples of 200 batches:

| Configured plugins | Before | After |
| --- | ---: | ---: |
| Empty list | 0.1911 ms | 0.1790 ms |
| One plugin | 0.1962 ms | 0.1772 ms |
| Three plugins | 0.2142 ms | 0.2140 ms |

The full minified ESM export set grows by 27 bytes gzip with esbuild 0.28.2 and ES2020.