### PR TITLE
fix: release closed Serializer state

### DIFF
--- a/.changeset/release-closed-serializer.md
+++ b/.changeset/release-closed-serializer.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Release private references and cleanup callbacks when a Serializer closes, prevent reentrant completion, and finish other writes' cleanup when a callback throws.

--- a/.changeset/release-stream-parser-state.md
+++ b/.changeset/release-stream-parser-state.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Release stream parser subscriptions and buffered nodes after use, and complete serialization once after buffered chunks are emitted.

--- a/packages/seroval/src/core/Serializer.ts
+++ b/packages/seroval/src/core/Serializer.ts
@@ -41,43 +41,46 @@ export default class Serializer {
     if (this.alive && !this.flushed) {
       this.pending++;
       this.keys.add(key);
-      this.cleanups.push(
-        crossSerializeStream(value, {
-          plugins: this.plugins,
-          scopeId: this.options.scopeId,
-          refs: this.refs,
-          disabledFeatures: this.options.disabledFeatures,
-          compactArrayBufferViews: this.options.compactArrayBufferViews,
-          onError: this.options.onError,
-          onSerialize: (data, initial) => {
-            if (this.alive) {
-              this.options.onData(
-                initial
-                  ? this.options.globalIdentifier +
-                      '["' +
-                      serializeString(key) +
-                      '"]=' +
-                      data
-                  : data,
-              );
+      const cleanup = crossSerializeStream(value, {
+        plugins: this.plugins,
+        scopeId: this.options.scopeId,
+        refs: this.refs,
+        disabledFeatures: this.options.disabledFeatures,
+        compactArrayBufferViews: this.options.compactArrayBufferViews,
+        onError: this.options.onError,
+        onSerialize: (data, initial) => {
+          if (this.alive) {
+            this.options.onData(
+              initial
+                ? this.options.globalIdentifier +
+                    '["' +
+                    serializeString(key) +
+                    '"]=' +
+                    data
+                : data,
+            );
+          }
+        },
+        onDone: () => {
+          if (this.alive) {
+            this.pending--;
+            if (
+              this.pending <= 0 &&
+              this.flushed &&
+              !this.done &&
+              this.options.onDone
+            ) {
+              this.done = true;
+              this.options.onDone();
             }
-          },
-          onDone: () => {
-            if (this.alive) {
-              this.pending--;
-              if (
-                this.pending <= 0 &&
-                this.flushed &&
-                !this.done &&
-                this.options.onDone
-              ) {
-                this.options.onDone();
-                this.done = true;
-              }
-            }
-          },
-        }),
-      );
+          }
+        },
+      });
+      if (this.alive) {
+        this.cleanups.push(cleanup);
+      } else {
+        cleanup();
+      }
     }
   }
 
@@ -100,22 +103,40 @@ export default class Serializer {
     if (this.alive) {
       this.flushed = true;
       if (this.pending <= 0 && !this.done && this.options.onDone) {
-        this.options.onDone();
         this.done = true;
+        this.options.onDone();
       }
     }
   }
 
   close(): void {
     if (this.alive) {
-      for (let i = 0, len = this.cleanups.length; i < len; i++) {
-        this.cleanups[i]();
-      }
-      if (!this.done && this.options.onDone) {
-        this.options.onDone();
-        this.done = true;
-      }
       this.alive = false;
+      let failure: { value: unknown } | undefined;
+      for (
+        let index = 0, length = this.cleanups.length;
+        index < length;
+        index++
+      ) {
+        try {
+          this.cleanups[index]();
+        } catch (error) {
+          failure ??= { value: error };
+        }
+      }
+      this.cleanups.length = 0;
+      this.refs.clear();
+      if (!this.done && this.options.onDone) {
+        this.done = true;
+        try {
+          this.options.onDone();
+        } catch (error) {
+          failure ??= { value: error };
+        }
+      }
+      if (failure) {
+        throw failure.value;
+      }
     }
   }
 }

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -445,34 +445,36 @@ function parseStream(
     return result;
   }
   pushPendingState(ctx);
-  current.on({
-    next: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamNextNode(id, parsed));
+  ctx.state.cleanups.push(
+    current.on({
+      next: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamNextNode(id, parsed));
+          }
         }
-      }
-    },
-    throw: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamThrowNode(id, parsed));
+      },
+      throw: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamThrowNode(id, parsed));
+          }
         }
-      }
-      popPendingState(ctx);
-    },
-    return: value => {
-      if (ctx.state.alive) {
-        const parsed = parseWithError(ctx, depth, value);
-        if (parsed) {
-          onParse(ctx, createStreamReturnNode(id, parsed));
+        popPendingState(ctx);
+      },
+      return: value => {
+        if (ctx.state.alive) {
+          const parsed = parseWithError(ctx, depth, value);
+          if (parsed) {
+            onParse(ctx, createStreamReturnNode(id, parsed));
+          }
         }
-      }
-      popPendingState(ctx);
-    },
-  });
+        popPendingState(ctx);
+      },
+    }),
+  );
   return result;
 }
 
@@ -932,16 +934,6 @@ function onError(ctx: StreamParserContext, error: unknown): void {
   }
 }
 
-function onDone(ctx: StreamParserContext): void {
-  if (ctx.state.onDone) {
-    ctx.state.onDone();
-  }
-
-  for (let i = 0, len = ctx.state.cleanups.length; i < len; i++) {
-    ctx.state.cleanups[i]();
-  }
-}
-
 function onParseInternal(
   ctx: StreamParserContext,
   node: SerovalNode,
@@ -959,8 +951,8 @@ function pushPendingState(ctx: StreamParserContext): void {
 }
 
 function popPendingState(ctx: StreamParserContext): void {
-  if (--ctx.state.pending <= 0) {
-    onDone(ctx);
+  if (--ctx.state.pending <= 0 && !ctx.state.initial) {
+    destroyStreamParse(ctx);
   }
 }
 
@@ -998,14 +990,37 @@ function flushStreamParse(
   ctx: StreamParserContext,
   state: StreamParserState,
 ): void {
-  for (let i = 0, len = state.buffer.length; i < len; i++) {
-    onParseInternal(ctx, state.buffer[i], false);
+  try {
+    for (
+      let index = 0, length = state.buffer.length;
+      index < length && state.alive;
+      index++
+    ) {
+      onParseInternal(ctx, state.buffer[index], false);
+    }
+  } finally {
+    state.buffer.length = 0;
   }
 }
 
 export function destroyStreamParse(ctx: StreamParserContext): void {
-  if (ctx.state.alive) {
-    onDone(ctx);
-    ctx.state.alive = false;
+  const state = ctx.state;
+  if (state.alive) {
+    state.alive = false;
+    try {
+      if (state.onDone) {
+        state.onDone();
+      }
+    } finally {
+      for (
+        let index = 0, length = state.cleanups.length;
+        index < length;
+        index++
+      ) {
+        state.cleanups[index]();
+      }
+      state.cleanups.length = 0;
+      state.buffer.length = 0;
+    }
   }
 }

--- a/packages/seroval/test/serializer.test.ts
+++ b/packages/seroval/test/serializer.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createStream, Serializer } from '../src';
+
+describe('Serializer lifecycle', () => {
+  it.each(['flush', 'close'] as const)(
+    'completes once when %s reenters close',
+    operation => {
+      const onData = vi.fn();
+      const onDone = vi.fn(() => {
+        writer.write('late', 2);
+        writer.close();
+      });
+      const writer = new Serializer({
+        globalIdentifier: 'values',
+        onData,
+        onDone,
+        onError: error => {
+          throw error;
+        },
+      });
+      writer.write('value', 1);
+      onData.mockClear();
+      writer[operation]();
+      writer.close();
+      expect(onDone).toHaveBeenCalledTimes(1);
+      expect(onData).not.toHaveBeenCalled();
+      expect([...writer.keys]).toEqual(['value']);
+    },
+  );
+
+  it('releases a subscription when onData closes an active write', () => {
+    const source = createStream<number>();
+    const subscribe = source.on;
+    let subscribed = false;
+    source.on = listener => {
+      subscribed = true;
+      const unsubscribe = subscribe(listener);
+      return () => {
+        subscribed = false;
+        unsubscribe();
+      };
+    };
+    const onData = vi.fn(() => writer.close());
+    const writer = new Serializer({
+      globalIdentifier: 'values',
+      onData,
+      onError: error => {
+        throw error;
+      },
+    });
+    writer.write('stream', source);
+    expect(subscribed).toBe(false);
+    onData.mockClear();
+    source.next(1);
+    expect(onData).not.toHaveBeenCalled();
+  });
+
+  it('releases every subscription when a cleanup throws', () => {
+    const failure = new Error('cleanup failed');
+    const sources = [createStream<number>(), createStream<number>()];
+    const active = new Set<number>();
+    sources.forEach((source, index) => {
+      const subscribe = source.on;
+      source.on = listener => {
+        active.add(index);
+        const unsubscribe = subscribe(listener);
+        return () => {
+          active.delete(index);
+          unsubscribe();
+          if (index === 0) {
+            throw failure;
+          }
+        };
+      };
+    });
+    const onDone = vi.fn();
+    const writer = new Serializer({
+      globalIdentifier: 'values',
+      onData: vi.fn(),
+      onDone,
+      onError: error => {
+        throw error;
+      },
+    });
+    sources.forEach((source, index) => {
+      writer.write(String(index), source);
+    });
+    expect(() => writer.close()).toThrow(failure);
+    expect([...active]).toEqual([]);
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(() => writer.close()).not.toThrow();
+  });
+
+  it('ignores pending promise output after closure', async () => {
+    let resolveValue: (value: number) => void = vi.fn();
+    const pending = new Promise<number>(resolve => {
+      resolveValue = resolve;
+    });
+    const onData = vi.fn();
+    const onDone = vi.fn();
+    const writer = new Serializer({
+      globalIdentifier: 'values',
+      onData,
+      onDone,
+      onError: error => {
+        throw error;
+      },
+    });
+    writer.write('value', pending);
+    writer.close();
+    onData.mockClear();
+    resolveValue(1);
+    await pending;
+    await Promise.resolve();
+    expect(onData).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes once when a flushed promise closes the writer', async () => {
+    const pending = Promise.resolve(1);
+    const onDone = vi.fn(() => writer.close());
+    const writer = new Serializer({
+      globalIdentifier: 'values',
+      onData: vi.fn(),
+      onDone,
+      onError: error => {
+        throw error;
+      },
+    });
+    writer.write('value', pending);
+    writer.flush();
+    await pending;
+    await Promise.resolve();
+    writer.close();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays closed when its completion callback throws', () => {
+    const failure = new Error('completion failed');
+    const onData = vi.fn();
+    const writer = new Serializer({
+      globalIdentifier: 'values',
+      onData,
+      onDone: () => {
+        throw failure;
+      },
+      onError: error => {
+        throw error;
+      },
+    });
+    writer.write('value', 1);
+    expect(() => writer.close()).toThrow(failure);
+    onData.mockClear();
+    writer.write('late', 2);
+    expect(() => writer.close()).not.toThrow();
+    expect(onData).not.toHaveBeenCalled();
+  });
+
+  it('keeps other writers reference state independent', () => {
+    const values: Record<string, unknown>[] = [{}, {}];
+    const writers = values.map(output => {
+      const refs: unknown[] = [];
+      return new Serializer({
+        globalIdentifier: 'values',
+        onData: source => new Function('values', '$R', source)(output, refs),
+        onError: error => {
+          throw error;
+        },
+      });
+    });
+    const shared = { value: 1 };
+    writers[0].write('first', shared);
+    writers[1].write('first', shared);
+    writers[0].close();
+    writers[1].write('again', shared);
+    writers[1].close();
+    expect(values[1].again).toBe(values[1].first);
+    expect(values[0].first).not.toBe(values[1].first);
+  });
+});

--- a/packages/seroval/test/stream-cancellation.test.ts
+++ b/packages/seroval/test/stream-cancellation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { crossSerializeStream, toCrossJSONStream } from '../src';
+import { createStream, crossSerializeStream, toCrossJSONStream } from '../src';
 
 const serializers = [
   [
@@ -13,6 +13,57 @@ const serializers = [
       crossSerializeStream(value, { onSerialize: emit }),
   ],
 ] as const;
+
+describe.each(serializers)('%s stream subscriptions', (name, serialize) => {
+  it.each(['cancel', 'return', 'throw'] as const)(
+    'releases its subscription after %s',
+    mode => {
+      const source = createStream<number>();
+      const subscribe = source.on;
+      let subscribed = false;
+      source.on = listener => {
+        subscribed = true;
+        const unsubscribe = subscribe(listener);
+        return () => {
+          subscribed = false;
+          unsubscribe();
+        };
+      };
+      const emit = vi.fn();
+      const cancel = serialize(source, emit);
+      expect(subscribed).toBe(true);
+      if (mode === 'cancel') {
+        cancel();
+      } else {
+        source[mode](1);
+      }
+      expect(subscribed).toBe(false);
+      emit.mockClear();
+      source.next(2);
+      expect(emit).not.toHaveBeenCalled();
+    },
+  );
+
+  it('completes once when the completion callback cancels serialization', () => {
+    const source = createStream<number>();
+    let completions = 0;
+    const options = {
+      onParse: vi.fn(),
+      onSerialize: vi.fn(),
+      onDone() {
+        completions++;
+        cancel();
+      },
+    };
+    const cancel =
+      name === 'JSON'
+        ? toCrossJSONStream(source, options)
+        : crossSerializeStream(source, options);
+    source.return(1);
+    cancel();
+    expect(completions).toBe(1);
+  });
+});
 
 describe.each(serializers)(
   '%s async iterator cancellation',

--- a/packages/seroval/test/stream-draining.test.ts
+++ b/packages/seroval/test/stream-draining.test.ts
@@ -1,7 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { fromCrossJSON, toCrossJSONStream } from '../src';
+import { createStream, fromCrossJSON, toCrossJSONStream } from '../src';
 
 describe('long async iterable streams', () => {
+  it('emits buffered chunks before completing once', () => {
+    const source = createStream<number>();
+    source.next(1);
+    source.return(2);
+    const events: string[] = [];
+    const refs = new Map();
+    let restored: ReturnType<typeof createStream<number>> | undefined;
+    const cancel = toCrossJSONStream(source, {
+      onParse(node, initial) {
+        const value = fromCrossJSON<ReturnType<typeof createStream<number>>>(
+          node,
+          { refs },
+        );
+        if (initial) {
+          restored = value;
+        }
+        events.push(initial ? 'initial' : 'chunk');
+      },
+      onDone() {
+        events.push('done');
+      },
+    });
+    cancel();
+    expect(events).toEqual(['initial', 'chunk', 'chunk', 'done']);
+    const values: number[] = [];
+    restored?.on({
+      next(value) {
+        values.push(value);
+      },
+      return(value) {
+        values.push(value);
+      },
+      throw(error) {
+        throw error;
+      },
+    });
+    expect(values).toEqual([1, 2]);
+  });
+
   it.each(['return', 'throw'])('preserves chunk order and %s', async mode => {
     async function* source() {
       await Promise.resolve();


### PR DESCRIPTION
Builds on #165. Close the writer before invoking callbacks, release its private reference map and cleanup handles, and finish the remaining writes' cleanup if one callback throws. Preserve public keys and prevent reentrant completion or writes after closure.

On Node 24.12.0, keeping a closed writer alive retained 1,000 of 1,000 input objects before this change and 0 after garbage collection. Compared with #165 (`f698afa`), the minified `Serializer` import grows by 75 bytes gzip with esbuild 0.28.2 and ES2020.