### PR TITLE
Preserve native web namespace for ESM tree shaking

### DIFF
--- a/.changeset/native-web-plugin-namespace.md
+++ b/.changeset/native-web-plugin-namespace.md
@@ -1,0 +1,5 @@
+---
+'seroval-plugins': patch
+---
+
+Improve tree shaking of web namespace imports in ESM builds while preserving the CommonJS export shape.

--- a/packages/plugins/tsdown.config.ts
+++ b/packages/plugins/tsdown.config.ts
@@ -1,4 +1,7 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsdown';
+
+const webEntry = fileURLToPath(new URL('./web', import.meta.url));
 
 export default defineConfig([
   {
@@ -12,6 +15,16 @@ export default defineConfig([
     dts: true,
     outDir: './dist/dev',
     format: ['esm', 'cjs'],
+    inputOptions(options, format) {
+      if (format === 'es') {
+        options.external = ['./web'];
+      }
+    },
+    outputOptions(options, format) {
+      if (format === 'es') {
+        options.paths = { [webEntry]: './web.js' };
+      }
+    },
     env: {
       PROD: false,
     },
@@ -27,6 +40,16 @@ export default defineConfig([
     dts: true,
 
     format: ['esm', 'cjs'],
+    inputOptions(options, format) {
+      if (format === 'es') {
+        options.external = ['./web'];
+      }
+    },
+    outputOptions(options, format) {
+      if (format === 'es') {
+        options.paths = { [webEntry]: './web.js' };
+      }
+    },
     env: {
       PROD: true,
     },


### PR DESCRIPTION
Keep `web` as a native ESM namespace that imports the existing web entry point. Rolldown can then remove unused plugins from static access such as `web.URLPlugin`. CommonJS output is unchanged.

Measured against `d675645bc4a5916fb8490b3b8a8d011528e82ee1` with Rolldown 1.2.3, browser ESM, ES2020, minification, gzip level 9, and Brotli quality 11:

| Consumer | gzip before -> after | Brotli before -> after |
| --- | ---: | ---: |
| Core + `web.URLPlugin` | 10,078 -> 8,162 B | 9,008 -> 7,321 B |
| Core + `web.RequestPlugin` | 10,078 -> 8,757 B | 9,008 -> 7,848 B |
| Plugin-only `web.URLPlugin` | 2,236 -> 238 B | 2,008 -> 199 B |
| Plugin-only `web.ReadableStreamPlugin` | 2,237 -> 581 B | 2,014 -> 517 B |

Core consumers include `serializeAsync`, `deserialize`, and their Seroval dependencies. Plugin-only consumers leave `seroval` external. The core + URL consumer is 19.0% smaller with gzip and 18.7% smaller with Brotli.

Direct imports from `seroval-plugins/web` are unchanged in these probes. esbuild 0.28.2 still retains the namespace and saves only 24 B gzip and 26 B Brotli for plugin-only `web.URLPlugin`; it does not get the large Rolldown reduction.