### PR TITLE
fix: report the depth limit error with its own code

### DIFF
--- a/.changeset/depth-limit-error-code.md
+++ b/.changeset/depth-limit-error-code.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Report the depth limit error with its own error code.

--- a/packages/seroval/src/core/errors.ts
+++ b/packages/seroval/src/core/errors.ts
@@ -189,7 +189,7 @@ export class SerovalDepthLimitError extends Error {
   constructor(limit: number) {
     super(
       import.meta.env.PROD
-        ? getSpecificErrorMessage(SpecificErrorCodes.ConflictedNodeId)
+        ? getSpecificErrorMessage(SpecificErrorCodes.DepthLimit)
         : 'Depth limit of ' + limit + ' reached',
     );
   }


### PR DESCRIPTION
`SerovalDepthLimitError` built its production message with `SpecificErrorCodes.ConflictedNodeId`, so a depth limit hit reported `Seroval Error (specific: 9)`, the same text as a conflicted node id. It now reports `Seroval Error (specific: 10)`. Development messages are unchanged.

Compatibility note: anything matching the production message text for depth limit errors sees code 10 instead of 9. The error class and `instanceof` behaviour are unchanged.
