### PR TITLE
perf: keep unused tables out of consumer bundles

### DIFF
--- a/.changeset/tree-shakeable-tables.md
+++ b/.changeset/tree-shakeable-tables.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Keep unused symbol and constant tables out of consumer bundles and register the reference store with one global lookup.

--- a/packages/seroval/src/core/constants.ts
+++ b/packages/seroval/src/core/constants.ts
@@ -115,21 +115,28 @@ export const SYMBOL_STRING: Record<Symbols, string> = {
   [Symbols.Unscopables]: 'Symbol.unscopables',
 };
 
-export const INV_SYMBOL_REF = {
-  [SYM_ASYNC_ITERATOR]: Symbols.AsyncIterator,
-  [SYM_HAS_INSTANCE]: Symbols.HasInstance,
-  [SYM_IS_CONCAT_SPREADABLE]: Symbols.IsConcatSpreadable,
-  [SYM_ITERATOR]: Symbols.Iterator,
-  [SYM_MATCH]: Symbols.Match,
-  [SYM_MATCH_ALL]: Symbols.MatchAll,
-  [SYM_REPLACE]: Symbols.Replace,
-  [SYM_SEARCH]: Symbols.Search,
-  [SYM_SPECIES]: Symbols.Species,
-  [SYM_SPLIT]: Symbols.Split,
-  [SYM_TO_PRIMITIVE]: Symbols.ToPrimitive,
-  [SYM_TO_STRING_TAG]: Symbols.ToStringTag,
-  [SYM_UNSCOPABLES]: Symbols.Unscopables,
-};
+// Built through a pure call: bundlers do not treat symbol-keyed (computed)
+// object literals as side-effect free, so an inline literal would be kept in
+// every consumer bundle even when unused.
+function createInverseSymbolTable() {
+  return {
+    [SYM_ASYNC_ITERATOR]: Symbols.AsyncIterator,
+    [SYM_HAS_INSTANCE]: Symbols.HasInstance,
+    [SYM_IS_CONCAT_SPREADABLE]: Symbols.IsConcatSpreadable,
+    [SYM_ITERATOR]: Symbols.Iterator,
+    [SYM_MATCH]: Symbols.Match,
+    [SYM_MATCH_ALL]: Symbols.MatchAll,
+    [SYM_REPLACE]: Symbols.Replace,
+    [SYM_SEARCH]: Symbols.Search,
+    [SYM_SPECIES]: Symbols.Species,
+    [SYM_SPLIT]: Symbols.Split,
+    [SYM_TO_PRIMITIVE]: Symbols.ToPrimitive,
+    [SYM_TO_STRING_TAG]: Symbols.ToStringTag,
+    [SYM_UNSCOPABLES]: Symbols.Unscopables,
+  };
+}
+
+export const INV_SYMBOL_REF = /* @__PURE__ */ createInverseSymbolTable();
 
 export type WellKnownSymbols = keyof typeof INV_SYMBOL_REF;
 
@@ -162,15 +169,20 @@ export const CONSTANT_STRING: Record<SerovalConstant, string> = {
 
 export const NIL = void 0;
 
+// Global literals keep this table free of member accesses so bundlers can
+// drop it when unused (`Number.POSITIVE_INFINITY` is not known to be pure).
 export const CONSTANT_VAL: Record<SerovalConstant, unknown> = {
   [SerovalConstant.True]: true,
   [SerovalConstant.False]: false,
   [SerovalConstant.Undefined]: NIL,
   [SerovalConstant.Null]: null,
   [SerovalConstant.NegZero]: -0,
-  [SerovalConstant.Inf]: Number.POSITIVE_INFINITY,
-  [SerovalConstant.NegInf]: Number.NEGATIVE_INFINITY,
-  [SerovalConstant.Nan]: Number.NaN,
+  // biome-ignore lint/style/useNumberNamespace: see above
+  [SerovalConstant.Inf]: Infinity,
+  // biome-ignore lint/style/useNumberNamespace: see above
+  [SerovalConstant.NegInf]: -Infinity,
+  // biome-ignore lint/style/useNumberNamespace: see above
+  [SerovalConstant.Nan]: NaN,
 };
 
 export const enum ErrorConstructorTag {

--- a/packages/seroval/src/core/errors.ts
+++ b/packages/seroval/src/core/errors.ts
@@ -3,12 +3,14 @@
 import { serializeString } from './string';
 import type { SerovalNode } from './types';
 
-const { toString: objectToString } = Object.prototype;
-
 const enum StepErrorCodes {
   Parse = 1,
   Serialize = 2,
   Deserialize = 3,
+}
+
+function objectToString(value: unknown): string {
+  return Object.prototype.toString.call(value);
 }
 
 function getErrorMessageDev(type: string, cause: unknown): string {
@@ -23,7 +25,7 @@ ${cause.message}
   }
   return `Seroval caught an error during the ${type} process.
 
-"${objectToString.call(cause)}"
+"${objectToString(cause)}"
 
 For more information, please check the "cause" property of this error.`;
 }
@@ -38,17 +40,16 @@ function getErrorMessageProd(type: string): string {
   return `Seroval Error (step: ${STEP_ERROR_CODES[type]})`;
 }
 
-const getErrorMessage = (type: string, cause: any) =>
-  import.meta.env.PROD
-    ? getErrorMessageProd(type)
-    : getErrorMessageDev(type, cause);
-
 export class SerovalError extends Error {
   constructor(
     type: string,
     public cause: unknown,
   ) {
-    super(getErrorMessage(type, cause));
+    super(
+      import.meta.env.PROD
+        ? getErrorMessageProd(type)
+        : getErrorMessageDev(type, cause),
+    );
   }
 }
 
@@ -92,7 +93,7 @@ export class SerovalUnsupportedTypeError extends Error {
     super(
       import.meta.env.PROD
         ? getSpecificErrorMessage(SpecificErrorCodes.UnsupportedType)
-        : `The value ${objectToString.call(value)} of type "${typeof value}" cannot be parsed/serialized.
+        : `The value ${objectToString(value)} of type "${typeof value}" cannot be parsed/serialized.
       
 There are few workarounds for this problem:
 - Transform the value in a way that it can be serialized.
@@ -137,7 +138,7 @@ export class SerovalMissingReferenceError extends Error {
       import.meta.env.PROD
         ? getSpecificErrorMessage(SpecificErrorCodes.MissingReference)
         : 'Missing reference for the value "' +
-            objectToString.call(value) +
+            objectToString(value) +
             '" of type "' +
             typeof value +
             '"',

--- a/packages/seroval/src/core/reference.ts
+++ b/packages/seroval/src/core/reference.ts
@@ -1,4 +1,4 @@
-import { SerovalMissingReferenceForIdError } from '..';
+import { SerovalMissingReferenceForIdError } from './errors';
 import { REFERENCES_KEY } from './keys';
 
 const REFERENCE = new Map<unknown, string>();
@@ -25,29 +25,26 @@ export function getReference<T>(id: string): T {
   throw new SerovalMissingReferenceForIdError(id);
 }
 
-if (typeof globalThis !== 'undefined') {
-  Object.defineProperty(globalThis, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof window !== 'undefined') {
-  Object.defineProperty(window, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof self !== 'undefined') {
-  Object.defineProperty(self, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof global !== 'undefined') {
-  Object.defineProperty(global, REFERENCES_KEY, {
+function getGlobalObject(): object | undefined {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  return undefined;
+}
+
+const GLOBAL_OBJECT = /* @__PURE__ */ getGlobalObject();
+
+if (GLOBAL_OBJECT) {
+  Object.defineProperty(GLOBAL_OBJECT, REFERENCES_KEY, {
     value: INV_REFERENCE,
     configurable: true,
     writable: false,


### PR DESCRIPTION
esbuild kept four module-level values in every bundle because it could not prove them side-effect free, even for consumers that only import `deserialize` or `createStream`:

- `INV_SYMBOL_REF`, a symbol-keyed object literal (computed keys are not treated as pure). It is now built through a `/* @__PURE__ */` call.
- `CONSTANT_VAL`, which read `Number.POSITIVE_INFINITY` and friends. It now uses the `Infinity` and `NaN` globals.
- `const { toString } = Object.prototype` in `errors.ts`, only needed for development messages. It is now read inside the development-only helper.
- The reference store registration, which was four near-identical `Object.defineProperty` branches. The global object is resolved once and the store is defined once.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2 and Rolldown 1.2.5, gzip level 9 and Brotli quality 11, compared with `a054acc`.

| Import | esbuild gzip | esbuild Brotli | Rolldown gzip | Rolldown Brotli |
| --- | ---: | ---: | ---: | ---: |
| Full export set | 12,462 -> 12,443 B | 11,183 -> 11,165 B | 12,172 -> 12,162 B | 10,920 -> 10,915 B |
| `serialize` | 8,545 -> 8,497 B | 7,702 -> 7,640 B | 8,304 -> 8,282 B | 7,452 -> 7,440 B |
| `deserialize` | 496 -> 238 B | 404 -> 202 B | 242 -> 235 B | 206 -> 194 B |
| `createStream` | 776 -> 510 B | 680 -> 473 B | 521 -> 507 B | 467 -> 463 B |
| Client set¹ | 4,356 -> 4,238 B | 3,921 -> 3,837 B | 4,139 -> 4,112 B | 3,737 -> 3,705 B |
| Server set² | 9,734 -> 9,681 B | 8,732 -> 8,701 B | 9,499 -> 9,484 B | 8,514 -> 8,514 B |

¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

`deserialize`-only consumers drop from 990 B to 350 B minified with esbuild. Rolldown already removed most of this, so its gains are smaller.

Security: the reference store is still defined on the same global, non-writable and non-enumerable, and the inverse symbol table has identical contents; it is just built once through a function call. Nothing consumer-facing changes.

On Node 24.12.0, `serialize`, `toJSON`, `fromJSON` and `fromCrossJSON` over a 300-object graph (dates, maps, sets, typed arrays, errors) stay within ±2% of `a054acc` across five alternating samples of 60 calls, which is inside run-to-run noise.
