### PR TITLE
perf: avoid downleveled nullish operators

### DIFF
--- a/.changeset/avoid-downleveled-nullish.md
+++ b/.changeset/avoid-downleveled-nullish.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Avoid nullish operators that the Node 10 build target downlevels into longer code.

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -116,7 +116,10 @@ export function createBaseDeserializerContext(
   mode: SerovalMode,
   options: BaseDeserializerContextOptions,
 ): BaseDeserializerContext {
-  const maxBase64Length = options.maxBase64Length ?? DEFAULT_MAX_BASE64_LENGTH;
+  const maxBase64Length =
+    options.maxBase64Length == null
+      ? DEFAULT_MAX_BASE64_LENGTH
+      : options.maxBase64Length;
   if (!Number.isSafeInteger(maxBase64Length) || maxBase64Length < 0) {
     throw new RangeError('maxBase64Length must be a non-negative safe integer');
   }
@@ -130,7 +133,10 @@ export function createBaseDeserializerContext(
     mode,
     plugins: options.plugins,
     refs: refs as BaseDeserializerContext['refs'],
-    features: options.features ?? ALL_ENABLED ^ (options.disabledFeatures || 0),
+    features:
+      options.features == null
+        ? ALL_ENABLED ^ (options.disabledFeatures || 0)
+        : options.features,
     depthLimit: options.depthLimit || DEFAULT_DEPTH_LIMIT,
     maxBase64Length,
   };
@@ -511,7 +517,7 @@ function deserializeTypedArray(
 ): TypedArrayValue | BigIntTypedArrayValue {
   const construct = getTypedArrayConstructor(node.c) as Int8ArrayConstructor;
   const source = deserialize(ctx, depth, node.f) as ArrayBuffer;
-  const offset = node.b ?? 0;
+  const offset = node.b == null ? 0 : node.b;
   if (offset < 0 || offset > source.byteLength) {
     throw new SerovalMalformedNodeError(node);
   }
@@ -529,7 +535,7 @@ function deserializeDataView(
   node: SerovalDataViewNode,
 ): DataView {
   const source = deserialize(ctx, depth, node.f) as ArrayBuffer;
-  const offset = node.b ?? 0;
+  const offset = node.b == null ? 0 : node.b;
   if (offset < 0 || offset > source.byteLength) {
     throw new SerovalMalformedNodeError(node);
   }

--- a/packages/seroval/src/core/context/parser.ts
+++ b/packages/seroval/src/core/context/parser.ts
@@ -66,7 +66,7 @@ export function createBaseParserContext(
     features: ALL_ENABLED ^ (options.disabledFeatures || 0),
     refs: options.refs || new Map(),
     depthLimit: options.depthLimit || 1000,
-    compactArrayBufferViews: options.compactArrayBufferViews ?? false,
+    compactArrayBufferViews: !!options.compactArrayBufferViews,
   };
 }
 

--- a/packages/seroval/src/core/stream.ts
+++ b/packages/seroval/src/core/stream.ts
@@ -39,16 +39,23 @@ export function createStreamFromAsyncIterable<T>(
   let cancelled = false;
   let done = false;
 
-  cleanups?.push(() => {
-    if (!(done || cancelled)) {
-      cancelled = true;
-      Promise.resolve()
-        .then(() => iterator.return?.())
-        .catch(() => {
-          // no-op
-        });
-    }
-  });
+  if (cleanups) {
+    cleanups.push(() => {
+      if (!(done || cancelled)) {
+        cancelled = true;
+        Promise.resolve()
+          .then(() => {
+            if (iterator.return) {
+              return iterator.return();
+            }
+            return undefined;
+          })
+          .catch(() => {
+            // no-op
+          });
+      }
+    });
+  }
 
   async function push(): Promise<void> {
     try {

--- a/packages/seroval/src/core/tree/index.ts
+++ b/packages/seroval/src/core/tree/index.ts
@@ -130,7 +130,7 @@ export function fromJSON<T>(
 ): T {
   const plugins = resolvePlugins(options.plugins);
   const disabledFeatures = options.disabledFeatures || 0;
-  const sourceFeatures = source.f ?? ALL_ENABLED;
+  const sourceFeatures = source.f == null ? ALL_ENABLED : source.f;
   const ctx = createVanillaDeserializerContext({
     maxBase64Length: options.maxBase64Length,
     plugins,


### PR DESCRIPTION
tsdown derives its syntax target from `engines.node` (`>=10`), so each `??` and `?.` in the source ships as `(_a = x) !== null && _a !== void 0 ? _a : y` with a hoisted temporary. This rewrites the handful of sites with explicit `== null` checks and an `if`, which produce the same result on every input (including `null` for `node.b`) without the temporaries.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2 and Rolldown 1.2.5, gzip level 9 and Brotli quality 11, compared with `a054acc`.

| Import | esbuild gzip | esbuild Brotli | Rolldown gzip | Rolldown Brotli |
| --- | ---: | ---: | ---: | ---: |
| Full export set | 12,462 -> 12,406 B | 11,183 -> 11,138 B | 12,172 -> 12,186 B | 10,920 -> 10,941 B |
| `serialize` | 8,545 -> 8,515 B | 7,702 -> 7,674 B | 8,304 -> 8,308 B | 7,452 -> 7,457 B |
| `toJSONAsync` + `fromCrossJSON` | 6,950 -> 6,907 B | 6,262 -> 6,219 B | 6,774 -> 6,788 B | 6,082 -> 6,090 B |
| Client set¹ | 4,356 -> 4,320 B | 3,921 -> 3,883 B | 4,139 -> 4,153 B | 3,737 -> 3,746 B |
| Server set² | 9,734 -> 9,707 B | 8,732 -> 8,707 B | 9,499 -> 9,501 B | 8,514 -> 8,514 B |

¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

The esbuild numbers drop; Rolldown's minifier already compacted the downleveled form, so its numbers move by a few bytes either way. If #180 (explicit ES2020 build target) lands instead, this one is unnecessary and can be closed.

On Node 24.12.0, `serialize`, `toJSON`, `fromJSON` and `fromCrossJSON` over a 300-object graph (dates, maps, sets, typed arrays, errors) stay within ±2% of `a054acc` across five alternating samples of 60 calls, which is inside run-to-run noise.
