### PR TITLE
perf: check extensibility first when reading object flags

### DIFF
--- a/.changeset/object-flag-fast-path.md
+++ b/.changeset/object-flag-fast-path.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Check extensibility first when reading object flags so ordinary objects need one native call.

--- a/packages/seroval/src/core/utils/get-object-flag.ts
+++ b/packages/seroval/src/core/utils/get-object-flag.ts
@@ -1,14 +1,16 @@
 import { SerovalObjectFlags } from '../constants';
 
 export function getObjectFlag(obj: unknown): SerovalObjectFlags {
+  // Extensible objects can be neither sealed nor frozen, so the common case
+  // needs a single native call.
+  if (Object.isExtensible(obj)) {
+    return SerovalObjectFlags.None;
+  }
   if (Object.isFrozen(obj)) {
     return SerovalObjectFlags.Frozen;
   }
   if (Object.isSealed(obj)) {
     return SerovalObjectFlags.Sealed;
-  }
-  if (Object.isExtensible(obj)) {
-    return SerovalObjectFlags.None;
   }
   return SerovalObjectFlags.NonExtensible;
 }


### PR DESCRIPTION
`getObjectFlag` ran `Object.isFrozen`, then `Object.isSealed`, then `Object.isExtensible` for every array and plain object. An extensible object can be neither sealed nor frozen, so checking `Object.isExtensible` first answers the common case with one native call instead of three. Non-extensible objects still resolve to `Frozen`, `Sealed` or `NonExtensible` in the same priority order, so emitted flags are unchanged.

On Node 24.12.0, `toJSON` over 20,000 plain objects each holding an array took a median 7.18 ms before and 6.71 ms after (-6.6%) across five alternating samples of 30 calls. Bundle size is unchanged within a few bytes.
