### PR TITLE
perf: build with an explicit ES2020 syntax target

### DIFF
--- a/.changeset/es2020-build-target.md
+++ b/.changeset/es2020-build-target.md
@@ -3,4 +3,4 @@
 'seroval-plugins': patch
 ---
 
-Build with an explicit ES2020 syntax target so nullish coalescing and optional chaining ship as written instead of being downleveled for Node 10.
+Build with an explicit ES2020 syntax target so the emitted syntax floor no longer follows `engines.node`, keeping nullish coalescing and optional chaining as written.

--- a/.changeset/es2020-build-target.md
+++ b/.changeset/es2020-build-target.md
@@ -1,0 +1,6 @@
+---
+'seroval': patch
+'seroval-plugins': patch
+---
+
+Build with an explicit ES2020 syntax target so nullish coalescing and optional chaining ship as written instead of being downleveled for Node 10.

--- a/packages/plugins/tsdown.config.ts
+++ b/packages/plugins/tsdown.config.ts
@@ -12,6 +12,7 @@ export default defineConfig([
       },
     ],
     platform: 'neutral',
+    target: 'es2020',
     dts: true,
     outDir: './dist/dev',
     format: ['esm', 'cjs'],
@@ -37,6 +38,7 @@ export default defineConfig([
       },
     ],
     platform: 'neutral',
+    target: 'es2020',
     dts: true,
 
     format: ['esm', 'cjs'],

--- a/packages/seroval/tsdown.config.ts
+++ b/packages/seroval/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig([
   {
     entry: 'src/index.ts',
     platform: 'neutral',
+    target: 'es2020',
     dts: true,
     outDir: './dist/dev',
     format: ['esm', 'cjs'],
@@ -14,6 +15,7 @@ export default defineConfig([
   {
     entry: 'src/index.ts',
     platform: 'neutral',
+    target: 'es2020',
     dts: true,
 
     format: ['esm', 'cjs'],


### PR DESCRIPTION
tsdown resolves its syntax target from `engines.node` when no `target` is set. With #187 raising `engines` to `>=20`, the derived target becomes `node20`, which permits any ES2022 syntax (`??=`, class fields, static blocks) to ship as written and would silently move the browser floor whenever a future source change uses one. Setting `target: 'es2020'` in both `tsdown.config.ts` files pins the emitted syntax independently of `engines`: nullish coalescing and optional chaining stay as written (six `??` and two `?.` in `seroval`), class fields are still lowered to constructor assignments, so the `Serializer` class output is unchanged.

Before #187 the same setting also stopped the Node 10 derived target from downleveling `??` and `?.` into `(_a = x) !== null && _a !== void 0 ? _a : y` with hoisted temporaries. The measurements below were taken against that baseline; on top of #187 the byte change is nil, since `node20` already keeps those operators.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2 and Rolldown 1.2.5, gzip level 9 and Brotli quality 11, compared with `a054acc`.

| Import | esbuild gzip | esbuild Brotli | Rolldown gzip | Rolldown Brotli |
| --- | ---: | ---: | ---: | ---: |
| Full export set | 12,462 -> 12,385 B | 11,183 -> 11,108 B | 12,172 -> 12,167 B | 10,920 -> 10,923 B |
| `serialize` | 8,545 -> 8,507 B | 7,702 -> 7,671 B | 8,304 -> 8,300 B | 7,452 -> 7,450 B |
| `toJSONAsync` + `fromCrossJSON` | 6,950 -> 6,887 B | 6,262 -> 6,195 B | 6,774 -> 6,770 B | 6,082 -> 6,080 B |
| Client set¹ | 4,356 -> 4,310 B | 3,921 -> 3,873 B | 4,139 -> 4,139 B | 3,737 -> 3,737 B |
| Server set² | 9,734 -> 9,697 B | 8,732 -> 8,704 B | 9,499 -> 9,495 B | 8,514 -> 8,513 B |

¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

Compatibility note: the published files contain ES2020 syntax. Browsers without `??`/`?.` (Chrome before 80, Safari before 13.1, Firefox before 72) need the consumer's bundler to downlevel, which Vite, esbuild and Rolldown do for their own targets. The Node floor is #187's `engines >=20`. `es2022` would also be valid for Node 20 and would let #170's `??=` ship as written, but it raises the browser floor to Safari 16.4, so this PR leaves it at `es2020`. #176 (avoid downleveled nullish operators) is closed as redundant.

On Node 24.12.0, `serialize`, `toJSON`, `fromJSON` and `fromCrossJSON` over a 300-object graph (dates, maps, sets, typed arrays, errors) stay within ±2% of `a054acc` across five alternating samples of 60 calls, which is inside run-to-run noise.
