### PR TITLE
perf: share marked references with serializer contexts

### DIFF
--- a/.changeset/share-marked-refs.md
+++ b/.changeset/share-marked-refs.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Share the parser's marked reference set with serializer contexts instead of copying it, so streaming serializers no longer pay O(references) per emitted node.

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -271,7 +271,12 @@ export function createBaseSerializerContext(
     mode,
     plugins: options.plugins,
     features: options.features,
-    marked: new Set(options.markedRefs),
+    // A Set passed by a parser is shared, not copied: streaming serializers
+    // create one context per emitted node, and copying the whole set each
+    // time made every emitted node cost O(references).
+    marked: Array.isArray(options.markedRefs)
+      ? new Set(options.markedRefs)
+      : options.markedRefs,
     stack: [],
     flags: [],
     assignments: [],


### PR DESCRIPTION
`crossSerializeStream` creates a new serializer context for every emitted node (each resolved promise, each stream chunk), and `createBaseSerializerContext` copied the parser's whole `marked` set into that context with `new Set(...)`. A stream over R shared references emitting C chunks therefore did O(R × C) set insertions just to make private copies. The parser's set is now shared; arrays (the `compileJSON` path, where `markedRefs` comes from JSON) are still copied into a fresh `Set`.

Time for `crossSerializeStream` to reach `onDone` on Node 24.12.0, medians of seven alternating runs, compared with `a054acc`:

| Shared references | Resolved promises | Before | After |
| ---: | ---: | ---: | ---: |
| 1,000 | 200 | 1.97 ms | 1.00 ms |
| 5,000 | 500 | 18.56 ms | 3.02 ms |
| 20,000 | 1,000 | 109.00 ms | 11.54 ms |

Serialized output is unchanged: every snapshot test passes, including the cyclic Map cases that consult the marked set for the sentinel form. The `Array.isArray` check adds 11 B gzip to the full export set with esbuild.

Compatibility note: serializer contexts now mutate a `Set` passed as `markedRefs` instead of copying it. Only the internal context creators accept that option (plugins never receive it), so no public API changes.
