### PR TITLE
perf: walk object properties without entry pairs

### DIFF
--- a/.changeset/parse-properties-keys.md
+++ b/.changeset/parse-properties-keys.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Walk object properties with Object.keys instead of Object.entries so parsing no longer allocates a key/value pair per property.

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -154,12 +154,13 @@ async function parseProperties(
   depth: number,
   properties: Record<string | symbol, unknown>,
 ): Promise<SerovalObjectRecordNode> {
-  const entries = Object.entries(properties);
+  const keys = Object.keys(properties);
   const keyNodes: SerovalObjectRecordKey[] = [];
   const valueNodes: SerovalNode[] = [];
-  for (let i = 0, len = entries.length; i < len; i++) {
-    keyNodes.push(serializeString(entries[i][0]));
-    valueNodes.push(await parseAsync(ctx, depth, entries[i][1]));
+  for (let i = 0, len = keys.length, key: string; i < len; i++) {
+    key = keys[i];
+    keyNodes.push(serializeString(key));
+    valueNodes.push(await parseAsync(ctx, depth, properties[key]));
   }
   // Check special properties
   if (SYM_ITERATOR in properties) {

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -254,12 +254,13 @@ function parseProperties(
   depth: number,
   properties: Record<string | symbol, unknown>,
 ): SerovalObjectRecordNode {
-  const entries = Object.entries(properties);
+  const keys = Object.keys(properties);
   const keyNodes: SerovalObjectRecordKey[] = [];
   const valueNodes: SerovalNode[] = [];
-  for (let i = 0, len = entries.length; i < len; i++) {
-    keyNodes.push(serializeString(entries[i][0]));
-    valueNodes.push(parseSOS(ctx, depth, entries[i][1]));
+  for (let i = 0, len = keys.length, key: string; i < len; i++) {
+    key = keys[i];
+    keyNodes.push(serializeString(key));
+    valueNodes.push(parseSOS(ctx, depth, properties[key]));
   }
   // Check special properties, symbols in this case
   if (SYM_ITERATOR in properties) {


### PR DESCRIPTION
`parseProperties` in both parsers used `Object.entries`, allocating a two-element array per property on the hottest parser path. `Object.keys` plus an indexed read visits the same own enumerable string keys in the same order, and V8 handles it much better for wide objects.

`toJSON` on Node 24.12.0, medians of five alternating samples of 40 calls, compared with `a054acc`:

| Objects × properties | Before | After |
| --- | ---: | ---: |
| 2,000 × 5 | 0.481 ms | 0.487 ms |
| 500 × 40 | 2.186 ms | 0.956 ms |
| 100 × 200 | 2.212 ms | 1.014 ms |

Narrow objects are unchanged within noise; objects with 40 or more properties parse about twice as fast. Bundle size is unchanged within a few bytes.

Compatibility note: accessor properties are now read as each property is parsed instead of all up front. An accessor that mutates the object while an earlier property's value is being parsed can observe the difference; ordinary data and getters do not. The set of keys visited is identical, so keys such as `__proto__` are still handled by the serializer's existing own-property paths.
