### PR TITLE
perf: inline feature bits inside the library

### DIFF
--- a/.changeset/feature-const-object.md
+++ b/.changeset/feature-const-object.md
@@ -1,0 +1,5 @@
+---
+'seroval': minor
+---
+
+Export `Feature` as a plain constant object with a matching `Feature` type instead of a runtime enum, and inline feature bits inside the library. Reverse lookups such as `Feature[1]` are no longer available.

--- a/.changeset/feature-const-object.md
+++ b/.changeset/feature-const-object.md
@@ -1,5 +1,5 @@
 ---
-'seroval': minor
+'seroval': patch
 ---
 
-Export `Feature` as a plain constant object with a matching `Feature` type instead of a runtime enum, and inline feature bits inside the library. Reverse lookups such as `Feature[1]` are no longer available.
+Inline feature bits inside the library with an internal `const enum`. The exported `Feature` enum is unchanged.

--- a/packages/seroval/src/core/compat.ts
+++ b/packages/seroval/src/core/compat.ts
@@ -4,7 +4,11 @@
  * - MDN
  */
 
-export enum Feature {
+/**
+ * Internal feature bits. A `const enum` so every use inside the library
+ * inlines to a literal.
+ */
+export const enum FeatureFlag {
   AggregateError = 0x01,
   // @deprecated
   ArrowFunction = 0x02,
@@ -15,11 +19,30 @@ export enum Feature {
   Temporal = 0x40,
 }
 
+/**
+ * Public feature bits for `disabledFeatures`. A plain object instead of a
+ * runtime enum so consumers that never import it pay nothing for it and
+ * consumers that do only ship the forward mapping. Values must match
+ * `FeatureFlag` (checked by test/feature.test.ts).
+ */
+export const Feature = {
+  AggregateError: 0x01,
+  /** @deprecated */
+  ArrowFunction: 0x02,
+  ErrorPrototypeStack: 0x04,
+  ObjectAssign: 0x08,
+  BigIntTypedArray: 0x10,
+  RegExp: 0x20,
+  Temporal: 0x40,
+} as const satisfies Record<keyof typeof FeatureFlag, number>;
+
+export type Feature = (typeof Feature)[keyof typeof Feature];
+
 export const ALL_ENABLED =
-  Feature.AggregateError |
-  Feature.ArrowFunction |
-  Feature.ErrorPrototypeStack |
-  Feature.ObjectAssign |
-  Feature.BigIntTypedArray |
-  Feature.RegExp |
-  Feature.Temporal;
+  FeatureFlag.AggregateError |
+  FeatureFlag.ArrowFunction |
+  FeatureFlag.ErrorPrototypeStack |
+  FeatureFlag.ObjectAssign |
+  FeatureFlag.BigIntTypedArray |
+  FeatureFlag.RegExp |
+  FeatureFlag.Temporal;

--- a/packages/seroval/src/core/compat.ts
+++ b/packages/seroval/src/core/compat.ts
@@ -20,23 +20,20 @@ export const enum FeatureFlag {
 }
 
 /**
- * Public feature bits for `disabledFeatures`. A plain object instead of a
- * runtime enum so consumers that never import it pay nothing for it and
- * consumers that do only ship the forward mapping. Values must match
- * `FeatureFlag` (checked by test/feature.test.ts).
+ * Public feature bits for `disabledFeatures`. Stays a runtime `enum` so the
+ * published declaration is unchanged for consumers. Its values must match
+ * the internal bits (checked by test/feature.test.ts).
  */
-export const Feature = {
-  AggregateError: 0x01,
-  /** @deprecated */
-  ArrowFunction: 0x02,
-  ErrorPrototypeStack: 0x04,
-  ObjectAssign: 0x08,
-  BigIntTypedArray: 0x10,
-  RegExp: 0x20,
-  Temporal: 0x40,
-} as const satisfies Record<keyof typeof FeatureFlag, number>;
-
-export type Feature = (typeof Feature)[keyof typeof Feature];
+export enum Feature {
+  AggregateError = 0x01,
+  // @deprecated
+  ArrowFunction = 0x02,
+  ErrorPrototypeStack = 0x04,
+  ObjectAssign = 0x08,
+  BigIntTypedArray = 0x10,
+  RegExp = 0x20,
+  Temporal = 0x40,
+}
 
 export const ALL_ENABLED =
   FeatureFlag.AggregateError |

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -22,7 +22,7 @@ import {
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
-import { Feature } from '../compat';
+import { FeatureFlag } from '../compat';
 import { NIL, SerovalNodeType, SerovalTemporalType } from '../constants';
 import {
   SerovalDepthLimitError,
@@ -572,11 +572,11 @@ export async function parseObjectAsync(
     return parsePromise(ctx, depth, id, current as unknown as Promise<unknown>);
   }
   const currentFeatures = ctx.base.features;
-  if (currentFeatures & Feature.RegExp && currentClass === RegExp) {
+  if (currentFeatures & FeatureFlag.RegExp && currentClass === RegExp) {
     return createRegExpNode(id, current as unknown as RegExp);
   }
   // BigInt Typed Arrays
-  if (currentFeatures & Feature.BigIntTypedArray) {
+  if (currentFeatures & FeatureFlag.BigIntTypedArray) {
     switch (currentClass) {
       case BigInt64Array:
       case BigUint64Array:
@@ -591,7 +591,7 @@ export async function parseObjectAsync(
     }
   }
   if (
-    currentFeatures & Feature.AggregateError &&
+    currentFeatures & FeatureFlag.AggregateError &&
     typeof AggregateError !== 'undefined' &&
     (currentClass === AggregateError || current instanceof AggregateError)
   ) {
@@ -602,7 +602,10 @@ export async function parseObjectAsync(
       current as unknown as AggregateError,
     );
   }
-  if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
+  if (
+    currentFeatures & FeatureFlag.Temporal &&
+    typeof Temporal !== 'undefined'
+  ) {
     switch (currentClass) {
       case Temporal.Instant:
         return createTemporalNode(

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -1,4 +1,4 @@
-import { ALL_ENABLED, Feature } from '../compat';
+import { ALL_ENABLED, FeatureFlag } from '../compat';
 import {
   CONSTANT_VAL,
   ERROR_CONSTRUCTOR,
@@ -396,7 +396,7 @@ function deserializeTemporal(
   ctx: DeserializerContext,
   node: SerovalTemporalNode,
 ): unknown {
-  if (!(ctx.base.features & Feature.Temporal)) {
+  if (!(ctx.base.features & FeatureFlag.Temporal)) {
     throw new SerovalUnsupportedNodeError(node);
   }
   let value: unknown;
@@ -435,7 +435,7 @@ function deserializeRegExp(
   ctx: DeserializerContext,
   node: SerovalRegExpNode,
 ): RegExp {
-  if (ctx.base.features & Feature.RegExp) {
+  if (ctx.base.features & FeatureFlag.RegExp) {
     const source = deserializeString(node.c);
     if (source.length > MAX_REGEXP_SOURCE_LENGTH) {
       throw new SerovalMalformedNodeError(node);

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -1,4 +1,4 @@
-import { Feature } from '../compat';
+import { FeatureFlag } from '../compat';
 import {
   CONSTANT_STRING,
   ERROR_CONSTRUCTOR_STRING,
@@ -821,7 +821,7 @@ function serializeDictionary(
 ): string {
   if (node.p) {
     const base = ctx.base;
-    if (base.features & Feature.ObjectAssign) {
+    if (base.features & FeatureFlag.ObjectAssign) {
       init = serializeWithObjectAssign(ctx, node, node.p, init);
     } else {
       markSerializerRef(base, node.i);
@@ -868,7 +868,7 @@ function serializeTemporal(
   ctx: SerializerContext,
   node: SerovalTemporalNode,
 ): string {
-  if (ctx.base.features & Feature.Temporal) {
+  if (ctx.base.features & FeatureFlag.Temporal) {
     return TEMPORAL_CONSTRUCTOR[node.c] + '.from("' + node.s + '")';
   }
   throw new SerovalUnsupportedNodeError(node);
@@ -878,7 +878,7 @@ function serializeRegExp(
   ctx: SerializerContext,
   node: SerovalRegExpNode,
 ): string {
-  if (ctx.base.features & Feature.RegExp) {
+  if (ctx.base.features & FeatureFlag.RegExp) {
     return '/' + deserializeString(node.c) + '/' + node.m;
   }
   throw new SerovalUnsupportedNodeError(node);

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -22,7 +22,7 @@ import {
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
-import { Feature } from '../compat';
+import { FeatureFlag } from '../compat';
 import { NIL, SerovalNodeType, SerovalTemporalType } from '../constants';
 import {
   SerovalDepthLimitError,
@@ -712,11 +712,11 @@ function parseObjectPhase2(
     return parsePromise(ctx, depth, id, current as unknown as Promise<unknown>);
   }
   const currentFeatures = ctx.base.features;
-  if (currentFeatures & Feature.RegExp && currentClass === RegExp) {
+  if (currentFeatures & FeatureFlag.RegExp && currentClass === RegExp) {
     return createRegExpNode(id, current as unknown as RegExp);
   }
   // BigInt Typed Arrays
-  if (currentFeatures & Feature.BigIntTypedArray) {
+  if (currentFeatures & FeatureFlag.BigIntTypedArray) {
     switch (currentClass) {
       case BigInt64Array:
       case BigUint64Array:
@@ -731,7 +731,7 @@ function parseObjectPhase2(
     }
   }
   if (
-    currentFeatures & Feature.AggregateError &&
+    currentFeatures & FeatureFlag.AggregateError &&
     typeof AggregateError !== 'undefined' &&
     (currentClass === AggregateError || current instanceof AggregateError)
   ) {
@@ -742,7 +742,10 @@ function parseObjectPhase2(
       current as unknown as AggregateError,
     );
   }
-  if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
+  if (
+    currentFeatures & FeatureFlag.Temporal &&
+    typeof Temporal !== 'undefined'
+  ) {
     switch (currentClass) {
       case Temporal.Instant:
         return createTemporalNode(

--- a/packages/seroval/src/core/utils/error.ts
+++ b/packages/seroval/src/core/utils/error.ts
@@ -1,4 +1,4 @@
-import { Feature } from '../compat';
+import { FeatureFlag } from '../compat';
 import { ERROR_CONSTRUCTOR_STRING, ErrorConstructorTag } from '../constants';
 
 type ErrorValue =
@@ -59,7 +59,7 @@ export function getErrorOptions(
     name = names[i];
     if (name !== 'name' && name !== 'message') {
       if (name === 'stack') {
-        if (features & Feature.ErrorPrototypeStack) {
+        if (features & FeatureFlag.ErrorPrototypeStack) {
           options = options || {};
           options[name] = error[name as keyof Error];
         }

--- a/packages/seroval/test/feature.test.ts
+++ b/packages/seroval/test/feature.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { Feature } from '../src';
+import { ALL_ENABLED, FeatureFlag } from '../src/core/compat';
+
+describe('Feature', () => {
+  it('exposes the same bits the library uses internally', () => {
+    expect(Feature.AggregateError).toBe(FeatureFlag.AggregateError);
+    expect(Feature.ArrowFunction).toBe(FeatureFlag.ArrowFunction);
+    expect(Feature.ErrorPrototypeStack).toBe(FeatureFlag.ErrorPrototypeStack);
+    expect(Feature.ObjectAssign).toBe(FeatureFlag.ObjectAssign);
+    expect(Feature.BigIntTypedArray).toBe(FeatureFlag.BigIntTypedArray);
+    expect(Feature.RegExp).toBe(FeatureFlag.RegExp);
+    expect(Feature.Temporal).toBe(FeatureFlag.Temporal);
+  });
+  it('covers every bit in ALL_ENABLED', () => {
+    let all = 0;
+    for (const bit of Object.values(Feature)) {
+      all |= bit;
+    }
+    expect(all).toBe(ALL_ENABLED);
+  });
+});


### PR DESCRIPTION
Every `Feature.X` read inside the library now goes through an internal `const enum` (`FeatureFlag`), so each check inlines to a literal instead of a property read on the enum object. The exported `Feature` stays a runtime `enum`, byte for byte the same declaration as before, so `Feature.X` reads, bitwise combinations, `Feature[1]` reverse lookups and `Feature` as a type all keep working. A test asserts the public values match the internal bits and that they cover `ALL_ENABLED`.

An earlier revision of this PR replaced the public enum with an `as const` object plus a union type. That changed the published declaration from `declare enum Feature` to a `const` and a `type`, which is an API change for anyone typing a bit combination as `Feature`, so it was reverted here. The size win from that revision only applied to bundles that import `Feature` (about 40 B gzip), and the internal inlining is kept.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2 and Rolldown 1.2.5, gzip level 9 and Brotli quality 11, compared with `a054acc`: `serialize`, the client set and the server set are unchanged within a few bytes, since the unused enum was already tree-shaken by the `@__PURE__` annotation on its IIFE.

On Node 24.12.0, `serialize`, `toJSON`, `fromJSON` and `fromCrossJSON` over a 300-object graph (dates, maps, sets, typed arrays, errors) stay within ±2% of `a054acc` across five alternating samples of 60 calls, which is inside run-to-run noise.

Tests: 907 passing.
