### PR TITLE
perf: define the reference store on first use

### DIFF
--- a/.changeset/lazy-reference-store.md
+++ b/.changeset/lazy-reference-store.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Define the global `__SEROVAL_REFS__` store on the first `createReference` call instead of at import time, and mark the package side-effect free so bundlers can drop unused modules.

--- a/packages/seroval/package.json
+++ b/packages/seroval/package.json
@@ -1,6 +1,7 @@
 {
   "name": "seroval",
   "type": "module",
+  "sideEffects": false,
   "version": "1.6.1",
   "files": [
     "dist"

--- a/packages/seroval/src/core/reference.ts
+++ b/packages/seroval/src/core/reference.ts
@@ -1,10 +1,49 @@
-import { SerovalMissingReferenceForIdError } from '..';
+import { SerovalMissingReferenceForIdError } from './errors';
 import { REFERENCES_KEY } from './keys';
 
 const REFERENCE = new Map<unknown, string>();
 const INV_REFERENCE = new Map<string, unknown>();
 
+let installed = false;
+
+function getGlobalObject(): object | undefined {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  return undefined;
+}
+
+// Serialized output resolves named references through the global
+// `__SEROVAL_REFS__` store. Defining it at import time is a side effect
+// that keeps this module in every consumer bundle, including ones that
+// never register a reference. The store can only resolve values that were
+// registered here, so it is defined on the first registration instead.
+function installReferenceStore(): void {
+  if (!installed) {
+    installed = true;
+    const globalObject = getGlobalObject();
+    if (globalObject) {
+      Object.defineProperty(globalObject, REFERENCES_KEY, {
+        value: INV_REFERENCE,
+        configurable: true,
+        writable: false,
+        enumerable: false,
+      });
+    }
+  }
+}
+
 export function createReference<T>(id: string, value: T): T {
+  installReferenceStore();
   REFERENCE.set(value, id);
   INV_REFERENCE.set(id, value);
   return value;
@@ -23,34 +62,4 @@ export function getReference<T>(id: string): T {
     return INV_REFERENCE.get(id) as T;
   }
   throw new SerovalMissingReferenceForIdError(id);
-}
-
-if (typeof globalThis !== 'undefined') {
-  Object.defineProperty(globalThis, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof window !== 'undefined') {
-  Object.defineProperty(window, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof self !== 'undefined') {
-  Object.defineProperty(self, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
-} else if (typeof global !== 'undefined') {
-  Object.defineProperty(global, REFERENCES_KEY, {
-    value: INV_REFERENCE,
-    configurable: true,
-    writable: false,
-    enumerable: false,
-  });
 }

--- a/packages/seroval/test/reference-store.test.ts
+++ b/packages/seroval/test/reference-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getCrossReferenceHeader } from '../src';
+
+const REFERENCES_KEY = '__SEROVAL_REFS__';
+
+type GlobalWithStore = typeof globalThis & {
+  [REFERENCES_KEY]?: Map<string, unknown>;
+};
+
+describe('reference store', () => {
+  it('is defined on the first registration instead of on import', async () => {
+    vi.resetModules();
+    Reflect.deleteProperty(globalThis, REFERENCES_KEY);
+    const seroval = await import('../src');
+    expect(
+      Object.getOwnPropertyDescriptor(globalThis, REFERENCES_KEY),
+    ).toBeUndefined();
+
+    const value = { store: true };
+    seroval.createReference('reference-store', value);
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      REFERENCES_KEY,
+    );
+    expect(descriptor).toMatchObject({
+      configurable: true,
+      enumerable: false,
+      writable: false,
+    });
+    expect(
+      (globalThis as GlobalWithStore)[REFERENCES_KEY]?.get('reference-store'),
+    ).toBe(value);
+    expect(seroval.deserialize(seroval.serialize(value))).toBe(value);
+  });
+
+  it('keeps the cross reference header independent of the store', () => {
+    expect(getCrossReferenceHeader()).toBe('self.$R=self.$R||[]');
+  });
+});


### PR DESCRIPTION
Serialized output resolves named references through the global `__SEROVAL_REFS__` store. `reference.ts` defined that store at import time, which was the last unconditional side effect in the package: every consumer bundle kept the module and its four `Object.defineProperty` branches, and `package.json` could not declare `sideEffects: false`, so bundlers that rely on that flag (webpack, Rspack) kept the whole entry module alive even when nothing from it was used.

- The store is now defined on the first `createReference` call. That is the only way it can hold anything to resolve, so any code that evaluates `__SEROVAL_REFS__.get(...)` still finds the store in place. The global object is resolved once through the same `globalThis` / `window` / `self` / `global` chain.
- `packages/seroval/package.json` declares `"sideEffects": false`. After this change every module-level statement in the build is a declaration or a `/* @__PURE__ */` call.
- `reference.ts` imports its error class from `./errors` instead of the package barrel, removing a circular import.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2, gzip level 9 and Brotli quality 11, compared with `a054acc`.

| Import | minified | gzip | Brotli |
| --- | ---: | ---: | ---: |
| Full export set | 45623 -> 45498 B | 12522 -> 12543 B | 11220 -> 11241 B |
| serialize | 26956 -> 26500 B | 8538 -> 8455 B | 7687 -> 7626 B |
| deserialize | 976 -> 524 B | 485 -> 349 B | 407 -> 274 B |
| createStream | 1533 -> 1081 B | 767 -> 641 B | 673 -> 559 B |
| Client set¹ | 12338 -> 12215 B | 4324 -> 4333 B | 3889 -> 3914 B |
| Server set² | 33972 -> 33847 B | 9696 -> 9707 B | 8709 -> 8703 B |
| Bare import | 929 -> 0 B | 451 -> 20 B | 370 -> 1 B |
¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

A bare `import {} from 'seroval'` now produces an empty bundle, and `deserialize`-only consumers drop from 976 B to 524 B minified. Sets that include `createReference` gain a few bytes from the install guard.

Behaviour: the only observable difference is that a realm which imports seroval but never calls `createReference` no longer has an empty `__SEROVAL_REFS__` on its global. Evaluating a payload with a named reference in such a realm previously resolved to `undefined` and now throws a `ReferenceError`; a reference that was never registered cannot be resolved either way. Realms that register references behave exactly as before, and the property keeps the same descriptor (configurable, non-writable, non-enumerable).

Overlaps with #175, which also touches the store registration in `reference.ts`; whichever lands second needs a trivial rebase.

Tests: 907 passing, including a new `reference-store.test.ts` that checks the store is absent after import, present with the same descriptor after the first registration, and used by `serialize` / `deserialize` round-trips.
