### PR TITLE
fix: honor depthLimit everywhere and wrap serializer errors

### DIFF
--- a/.changeset/entry-point-options.md
+++ b/.changeset/entry-point-options.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Honor `depthLimit` in every serializer entry point and in `fromJSON`, wrap failures raised while emitting output in `SerovalSerializationError`, and report a node id that is assigned twice with `SerovalConflictedNodeIdError`.

--- a/packages/seroval/src/core/Serializer.ts
+++ b/packages/seroval/src/core/Serializer.ts
@@ -11,6 +11,7 @@ export interface SerializerOptions extends PluginAccessOptions {
   scopeId?: string;
   disabledFeatures?: number;
   compactArrayBufferViews?: boolean;
+  depthLimit?: number;
   onData: (result: string) => void;
   onError: (error: unknown) => void;
   onDone?: () => void;
@@ -48,6 +49,7 @@ export default class Serializer {
           refs: this.refs,
           disabledFeatures: this.options.disabledFeatures,
           compactArrayBufferViews: this.options.compactArrayBufferViews,
+          depthLimit: this.options.depthLimit,
           onError: this.options.onError,
           onSerialize: (data, initial) => {
             if (this.alive) {

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -14,6 +14,7 @@ import {
   type PromiseConstructorResolver,
 } from '../constructors';
 import {
+  SerovalConflictedNodeIdError,
   SerovalDepthLimitError,
   SerovalDeserializationError,
   SerovalMalformedNodeError,
@@ -199,14 +200,12 @@ export class DeserializePluginContext {
 }
 
 function guardIndexedValue(ctx: BaseDeserializerContext, id: number): void {
-  if (id < 0 || !Number.isFinite(id) || !Number.isInteger(id)) {
-    throw new SerovalMalformedNodeError({
-      t: SerovalNodeType.IndexedValue,
-      i: id,
-    } as SerovalNode);
+  const node = { t: SerovalNodeType.IndexedValue, i: id } as SerovalNode;
+  if (id < 0 || !Number.isInteger(id)) {
+    throw new SerovalMalformedNodeError(node);
   }
   if (ctx.refs.has(id)) {
-    throw new Error('Conflicted ref id: ' + id);
+    throw new SerovalConflictedNodeIdError(node);
   }
 }
 

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -1468,20 +1468,7 @@ function serialize(ctx: SerializerContext, node: SerovalNode): string {
   }
 }
 
-export function serializeRoot(
-  ctx: SerializerContext,
-  node: SerovalNode,
-): string {
-  try {
-    return serialize(ctx, node);
-  } catch (error) {
-    throw error instanceof SerovalSerializationError
-      ? error
-      : new SerovalSerializationError(error);
-  }
-}
-
-export function serializeTopVanilla(
+function serializeVanilla(
   ctx: VanillaSerializerContext,
   tree: SerovalNode,
 ): string {
@@ -1507,7 +1494,7 @@ export function serializeTopVanilla(
   return result;
 }
 
-export function serializeTopCross(
+function serializeCross(
   ctx: CrossSerializerContext,
   tree: SerovalNode,
 ): string {
@@ -1546,4 +1533,32 @@ export function serializeTopCross(
         '"])';
   // Create the IIFE
   return '(' + createFunction([params], body) + ')' + args;
+}
+
+function wrapSerializationError(error: unknown): SerovalSerializationError {
+  return error instanceof SerovalSerializationError
+    ? error
+    : new SerovalSerializationError(error);
+}
+
+export function serializeTopVanilla(
+  ctx: VanillaSerializerContext,
+  tree: SerovalNode,
+): string {
+  try {
+    return serializeVanilla(ctx, tree);
+  } catch (error) {
+    throw wrapSerializationError(error);
+  }
+}
+
+export function serializeTopCross(
+  ctx: CrossSerializerContext,
+  tree: SerovalNode,
+): string {
+  try {
+    return serializeCross(ctx, tree);
+  } catch (error) {
+    throw wrapSerializationError(error);
+  }
 }

--- a/packages/seroval/src/core/cross/index.ts
+++ b/packages/seroval/src/core/cross/index.ts
@@ -38,6 +38,7 @@ export function crossSerialize<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Cross, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -63,6 +64,7 @@ export async function crossSerializeAsync<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Cross, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -86,6 +88,7 @@ export function toCrossJSON<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Cross, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -102,6 +105,7 @@ export async function toCrossJSONAsync<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Cross, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
     refs: options.refs,
@@ -122,6 +126,7 @@ export function crossSerializeStream<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createStreamParserContext({
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     refs: options.refs,
     disabledFeatures: options.disabledFeatures,

--- a/packages/seroval/src/core/tree/index.ts
+++ b/packages/seroval/src/core/tree/index.ts
@@ -30,6 +30,7 @@ export function serialize<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Vanilla, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -49,6 +50,7 @@ export async function serializeAsync<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Vanilla, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -73,7 +75,7 @@ export interface SerovalJSON {
 
 export interface FromJSONOptions
   extends PluginAccessOptions,
-    Pick<BaseDeserializerContextOptions, 'maxBase64Length'> {
+    Pick<BaseDeserializerContextOptions, 'depthLimit' | 'maxBase64Length'> {
   disabledFeatures?: number;
 }
 
@@ -84,6 +86,7 @@ export function toJSON<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createSyncParserContext(SerovalMode.Vanilla, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -101,6 +104,7 @@ export async function toJSONAsync<T>(
   const plugins = resolvePlugins(options.plugins);
   const ctx = createAsyncParserContext(SerovalMode.Vanilla, {
     compactArrayBufferViews: options.compactArrayBufferViews,
+    depthLimit: options.depthLimit,
     plugins,
     disabledFeatures: options.disabledFeatures,
   });
@@ -132,6 +136,7 @@ export function fromJSON<T>(
   const disabledFeatures = options.disabledFeatures || 0;
   const sourceFeatures = source.f ?? ALL_ENABLED;
   const ctx = createVanillaDeserializerContext({
+    depthLimit: options.depthLimit,
     maxBase64Length: options.maxBase64Length,
     plugins,
     markedRefs: source.m,

--- a/packages/seroval/test/entry-point-options.test.ts
+++ b/packages/seroval/test/entry-point-options.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compileJSON,
+  createPlugin,
+  crossSerialize,
+  crossSerializeAsync,
+  crossSerializeStream,
+  fromJSON,
+  Serializer,
+  SerovalConflictedNodeIdError,
+  SerovalDepthLimitError,
+  SerovalDeserializationError,
+  SerovalMissingPluginError,
+  SerovalParserError,
+  SerovalSerializationError,
+  serialize,
+  serializeAsync,
+  toCrossJSON,
+  toCrossJSONAsync,
+  toJSON,
+  toJSONAsync,
+} from '../src';
+
+function createNested(depth: number): Record<string, unknown> {
+  let current: Record<string, unknown> = {};
+  const root = current;
+  for (let i = 0; i < depth; i++) {
+    const next: Record<string, unknown> = {};
+    current.child = next;
+    current = next;
+  }
+  return root;
+}
+
+const DEEP = createNested(20);
+const OPTIONS = { depthLimit: 4 };
+
+function expectDepthLimit(error: unknown): void {
+  expect(error).toBeInstanceOf(SerovalParserError);
+  expect((error as SerovalParserError).cause).toBeInstanceOf(
+    SerovalDepthLimitError,
+  );
+}
+
+describe('depthLimit', () => {
+  it('is honored by the sync entry points', () => {
+    for (const entry of [serialize, toJSON, crossSerialize, toCrossJSON]) {
+      expect(() => entry(createNested(2), OPTIONS)).not.toThrow();
+      let caught: unknown;
+      try {
+        entry(DEEP, OPTIONS);
+      } catch (error) {
+        caught = error;
+      }
+      expectDepthLimit(caught);
+    }
+  });
+
+  it('is honored by the async entry points', async () => {
+    for (const entry of [
+      serializeAsync,
+      toJSONAsync,
+      crossSerializeAsync,
+      toCrossJSONAsync,
+    ]) {
+      await expect(entry(createNested(2), OPTIONS)).resolves.toBeDefined();
+      expectDepthLimit(await entry(DEEP, OPTIONS).catch(error => error));
+    }
+  });
+
+  it('is honored by crossSerializeStream', async () => {
+    const error = await new Promise<unknown>(resolve => {
+      crossSerializeStream(DEEP, {
+        ...OPTIONS,
+        onSerialize() {
+          resolve(new Error('serialized past the depth limit'));
+        },
+        onError: resolve,
+      });
+    });
+    expect(error).toBeInstanceOf(SerovalDepthLimitError);
+  });
+
+  it('is honored by Serializer', async () => {
+    const error = await new Promise<unknown>(resolve => {
+      const writer = new Serializer({
+        ...OPTIONS,
+        globalIdentifier: '_$',
+        onData() {
+          resolve(new Error('serialized past the depth limit'));
+        },
+        onError: resolve,
+      });
+      writer.write('deep', DEEP);
+    });
+    expect(error).toBeInstanceOf(SerovalDepthLimitError);
+  });
+
+  it('is honored by fromJSON', () => {
+    const json = toJSON(DEEP);
+    expect(fromJSON(json)).toEqual(DEEP);
+    let caught: unknown;
+    try {
+      fromJSON(json, OPTIONS);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SerovalDeserializationError);
+    expect((caught as SerovalDeserializationError).cause).toBeInstanceOf(
+      SerovalDepthLimitError,
+    );
+  });
+});
+
+describe('SerovalSerializationError', () => {
+  const ExamplePlugin = createPlugin<URL, { href: unknown }>({
+    tag: 'example',
+    test(value) {
+      return value instanceof URL;
+    },
+    parse: {
+      sync(value, ctx) {
+        return { href: ctx.parse(value.href) };
+      },
+    },
+    serialize(node, ctx) {
+      return 'new URL(' + ctx.serialize(node.href as never) + ')';
+    },
+    deserialize(node, ctx) {
+      return new URL(ctx.deserialize(node.href as never));
+    },
+  });
+
+  it('wraps failures raised while emitting the output', () => {
+    const json = toJSON(new URL('https://example.com/'), {
+      plugins: [ExamplePlugin],
+    });
+    let caught: unknown;
+    try {
+      compileJSON(json);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SerovalSerializationError);
+    expect((caught as SerovalSerializationError).cause).toBeInstanceOf(
+      SerovalMissingPluginError,
+    );
+  });
+});
+
+describe('SerovalConflictedNodeIdError', () => {
+  it('reports a node id that is assigned twice', () => {
+    const json = JSON.parse(
+      '{"t":{"t":9,"i":0,"a":[{"t":9,"i":0,"a":[]}]},"f":127,"m":[0]}',
+    );
+    let caught: unknown;
+    try {
+      fromJSON(json);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SerovalDeserializationError);
+    expect((caught as SerovalDeserializationError).cause).toBeInstanceOf(
+      SerovalConflictedNodeIdError,
+    );
+  });
+});


### PR DESCRIPTION
Three correctness fixes at the public entry points, grouped because they touch the same files and all change what a caller observes on failure.

**`depthLimit` was silently ignored.** Every parser options type accepted it, but only `toCrossJSONStream` and `fromCrossJSON` forwarded it to the context. `serialize`, `serializeAsync`, `toJSON`, `toJSONAsync`, `fromJSON`, `crossSerialize`, `crossSerializeAsync`, `toCrossJSON`, `toCrossJSONAsync`, `crossSerializeStream` and `Serializer` all used the 1000 default regardless of the option. They now forward it. `Serializer` gains a `depthLimit` option and `FromJSONOptions` picks it up alongside `maxBase64Length`.

**`SerovalSerializationError` was never thrown.** `serializeRoot` wrapped emit-time failures but had no callers. `serializeTopVanilla` and `serializeTopCross` now wrap, which matches `parseTop`, `parseTopAsync` and `deserializeTop`. A `compileJSON` call without the plugin that produced the tree used to throw a bare `SerovalMissingPluginError`; it now throws `SerovalSerializationError` with that error as `cause`. Code that catches a specific inner class from a serializer entry point needs to look at `cause`, so this is called out in the changeset.

**A node id assigned twice during deserialization threw a plain `Error`.** `SerovalConflictedNodeIdError` already existed for this and is now used, so `fromJSON` on a tampered tree surfaces a typed cause like every other malformed-node case.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2, gzip level 9 and Brotli quality 11, compared with `a054acc`.

| Import | minified | gzip |
| --- | ---: | ---: |
| Full export set | 45,623 -> 46,026 B | 12,522 -> 12,541 B |
| `serialize` | 26,956 -> 27,150 B | 8,538 -> 8,572 B |
| `deserialize` | 976 -> 976 B | 485 -> 485 B |
| Client set¹ | 12,338 -> 12,372 B | 4,324 -> 4,309 B |
| Server set² | 33,972 -> 34,249 B | 9,696 -> 9,743 B |

¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

The 20 to 50 B gzip growth is the option forwarding plus the two try/catch wrappers.

Tests: 912 passing. New `entry-point-options.test.ts` covers `depthLimit` on all eleven entry points including the streaming callbacks, the `SerovalSerializationError` wrapping with `cause`, and the conflicted-id error class.
