### PR TITLE
perf: skip the number parse for non-numeric object keys

### DIFF
--- a/.changeset/serializer-key-kinds.md
+++ b/.changeset/serializer-key-kinds.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Classify object keys with a first-character check so the serializer only parses keys that can be numeric, and emit deferred key assignments through one helper.

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -118,6 +118,15 @@ type Assignment =
   | DeleteAssignment
   | DefineAssignment;
 
+const enum KeyKind {
+  // Needs a quoted string: `"a-b":` and `["a-b"]`
+  Quoted = 0,
+  // A valid identifier: `foo:` and `.foo`
+  Identifier = 1,
+  // A canonical non-negative number: `0:` and `[0]`
+  Numeric = 2,
+}
+
 export interface FlaggedObject {
   type: SerovalObjectFlags;
   value: string;
@@ -538,6 +547,24 @@ function createSequenceAssign(
  * Checks if the value is in the stack. Stack here is a reference
  * structure to know if a object is to be accessed in a TDZ.
  */
+function getKeyKind(key: string): KeyKind {
+  const first = key.charCodeAt(0);
+  // Canonical non-negative numbers start with a digit ('0'..'9') or are
+  // "Infinity"; every other key skips the number parse.
+  if (first >= 48 && first <= 57) {
+    const check = Number(key);
+    // Converting the number back must yield the original key, so that
+    // `{ '0x1': 1 }` is not confused with `{ 0x1: 1 }`.
+    return check >= 0 && check.toString() === key
+      ? KeyKind.Numeric
+      : KeyKind.Quoted;
+  }
+  if (key === 'Infinity') {
+    return KeyKind.Numeric;
+  }
+  return isValidIdentifier(key) ? KeyKind.Identifier : KeyKind.Quoted;
+}
+
 function isIndexedValueInStack(
   ctx: BaseSerializerContext,
   node: SerovalNode,
@@ -635,39 +662,28 @@ function serializeProperty(
   val: SerovalNode,
 ): string {
   if (typeof key === 'string') {
-    const check = Number(key);
-    const isIdentifier =
-      // Test if key is a valid positive number or JS identifier
-      // so that we don't have to serialize the key and wrap with brackets
-      (check >= 0 &&
-        // It's also important to consider that if the key is
-        // indeed numeric, we need to make sure that when
-        // converted back into a string, it's still the same
-        // to the original key. This allows us to differentiate
-        // keys that has numeric formats but in a different
-        // format, which can cause unintentional key declaration
-        // Example: { 0x1: 1 } vs { '0x1': 1 }
-        check.toString() === key) ||
-      isValidIdentifier(key);
+    const kind = getKeyKind(key);
     if (isIndexedValueInStack(ctx.base, val)) {
       const refParam = getRefParam(ctx, (val as SerovalIndexedValueNode).i);
       markSerializerRef(ctx.base, source.i);
-      // Strict identifier check, make sure
-      // that it isn't numeric (except NaN)
-      if (isIdentifier && check !== check) {
+      if (kind === KeyKind.Identifier) {
         createObjectAssign(ctx, source.i, key, refParam);
       } else {
         createArrayAssign(
           ctx,
           source.i,
-          isIdentifier ? key : '"' + key + '"',
+          kind === KeyKind.Numeric ? key : '"' + key + '"',
           refParam,
         );
       }
       return '';
     }
     if (isValidKey(key)) {
-      return (isIdentifier ? key : '"' + key + '"') + ':' + serialize(ctx, val);
+      return (
+        (kind === KeyKind.Quoted ? '"' + key + '"' : key) +
+        ':' +
+        serialize(ctx, val)
+      );
     }
     // `__proto__` as an identifier or string key in an object literal is the
     // prototype setter, not an own property; use a computed key so the
@@ -728,47 +744,32 @@ function serializeStringKeyAssignment(
 ): void {
   const base = ctx.base;
   const serialized = serialize(ctx, value);
-  const check = Number(key);
-  const isIdentifier =
-    // Test if key is a valid positive number or JS identifier
-    // so that we don't have to serialize the key and wrap with brackets
-    (check >= 0 &&
-      // It's also important to consider that if the key is
-      // indeed numeric, we need to make sure that when
-      // converted back into a string, it's still the same
-      // to the original key. This allows us to differentiate
-      // keys that has numeric formats but in a different
-      // format, which can cause unintentional key declaration
-      // Example: { 0x1: 1 } vs { '0x1': 1 }
-      check.toString() === key) ||
-    isValidIdentifier(key);
-  if (isIndexedValueInStack(base, value)) {
-    // Strict identifier check, make sure
-    // that it isn't numeric (except NaN)
-    if (isIdentifier && check !== check) {
-      createObjectAssign(ctx, source.i, key, serialized);
-    } else {
-      createArrayAssign(
-        ctx,
-        source.i,
-        isIdentifier ? key : '"' + key + '"',
-        serialized,
-      );
-    }
-  } else {
-    const parentAssignment = base.assignments;
+  const parentAssignment = base.assignments;
+  // A value that references a parent must wait for the parent to exist,
+  // so it stays in the outer assignment list.
+  if (!isIndexedValueInStack(base, value)) {
     base.assignments = mainAssignments;
-    if (isIdentifier && check !== check) {
-      createObjectAssign(ctx, source.i, key, serialized);
-    } else {
-      createArrayAssign(
-        ctx,
-        source.i,
-        isIdentifier ? key : '"' + key + '"',
-        serialized,
-      );
-    }
-    base.assignments = parentAssignment;
+  }
+  createKeyAssign(ctx, source.i, getKeyKind(key), key, serialized);
+  base.assignments = parentAssignment;
+}
+
+function createKeyAssign(
+  ctx: SerializerContext,
+  ref: number,
+  kind: KeyKind,
+  key: string,
+  value: string,
+): void {
+  if (kind === KeyKind.Identifier) {
+    createObjectAssign(ctx, ref, key, value);
+  } else {
+    createArrayAssign(
+      ctx,
+      ref,
+      kind === KeyKind.Numeric ? key : '"' + key + '"',
+      value,
+    );
   }
 }
 


### PR DESCRIPTION
`serializeProperty` and `serializeStringKeyAssignment` classified every string key of every object by running `Number(key)`, `check.toString() === key` and the identifier regex, and the two call sites carried duplicate copies of that logic. On a 10k-record graph the classification was about 14% of serializer self time in a CPU profile.

A canonical non-negative number string always starts with a digit or is `"Infinity"`, so keys that start with anything else now skip the number parse and go straight to `isValidIdentifier`. The three outcomes are one `KeyKind` enum (quoted, identifier, numeric) consumed by both call sites, and deferred key assignments go through one `createKeyAssign` helper. Output is byte-identical: every snapshot passes and the benchmark below asserts equality of `main` and branch output for each case.

I also tried caching key kinds per context (a `Map` keyed by string) and converting the cycle stack to a `Set`. The cache regressed dictionaries with unique keys by 10 to 20%, and the `Set` gave nothing the fast path did not already give, so neither is included.

Timings on Node 24.14.1, best of five runs, `main` = `a054acc`:

| Case | main | branch |
| --- | ---: | ---: |
| 10k records (4 keys each, nested) | 33.4 ms | 26.8 ms |
| Object with 20k unique keys | 7.6 ms | 7.1 ms |
| 900-deep nested arrays | 0.76 ms | 0.68 ms |
| 5k objects sharing a cyclic parent | 7.3 ms | 5.9 ms |

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2, gzip level 9, compared with `a054acc`:

| Import | minified | gzip |
| --- | ---: | ---: |
| Full export set | 45,623 -> 45,668 B | 12,522 -> 12,565 B |
| `serialize` | 26,956 -> 27,001 B | 8,538 -> 8,580 B |

The 42 B gzip growth is the digit check and the `"Infinity"` case; the old duplicated blocks compressed well against each other.

Overlaps #163 in `serializeProperty`, which introduces `getPropertyKeyType` for the same classification. Whichever lands second needs a rebase of that one function.
