### PR TITLE
chore: package metadata, runtime compatibility, and trust boundary docs

### DIFF
--- a/.changeset/package-metadata.md
+++ b/.changeset/package-metadata.md
@@ -1,6 +1,6 @@
 ---
-'seroval': patch
-'seroval-plugins': patch
+'seroval': minor
+'seroval-plugins': minor
 ---
 
-Resolve known-value lookups with `hasOwnProperty.call` instead of `Object.hasOwn` so the build runs on the runtimes it targets, remove the no-op `typesVersions` from seroval, give seroval-plugins `main`, `module` and `types` fields plus a `typesVersions` entry that points at the emitted `web` declarations, and link the plugins package to the workspace copy of seroval.
+Raise the supported Node.js floor from `>=10` to `>=20` in `engines`, remove the no-op `typesVersions` from seroval, give seroval-plugins `main`, `module` and `types` fields plus a `typesVersions` entry that points at the emitted `web` declarations, and link the plugins package to the workspace copy of seroval.

--- a/.changeset/package-metadata.md
+++ b/.changeset/package-metadata.md
@@ -1,0 +1,6 @@
+---
+'seroval': patch
+'seroval-plugins': patch
+---
+
+Resolve known-value lookups with `hasOwnProperty.call` instead of `Object.hasOwn` so the build runs on the runtimes it targets, remove the no-op `typesVersions` from seroval, give seroval-plugins `main`, `module` and `types` fields plus a `typesVersions` entry that points at the emitted `web` declarations, and link the plugins package to the workspace copy of seroval.

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -299,6 +299,27 @@ according to the receiving application's needs; it is a per-buffer limit, not a
 total payload or memory budget. JavaScript evaluation through `deserialize` does
 not use these JSON decoding limits.
 
+## Trust boundary
+
+The JSON form is safe to receive from an untrusted source only in one
+direction. `fromJSON` and `fromCrossJSON` validate the tree they are given:
+unknown node types, constructor names and constants are rejected, reserved
+property names are defined as own properties instead of assigned, and the
+decoding limits above bound the work a single node can cause.
+
+`compileJSON` does not validate. It turns a tree into JavaScript source by
+concatenating node fields, and it assumes the tree came from `toJSON` or
+`toJSONAsync` in a process you control. A tree from an untrusted source can
+smuggle code into the output through any string field, for example the flags
+of a RegExp node or the value of a Number node, and that code runs when the
+output is evaluated. The same applies to a plugin's `serialize` method, which
+receives the plugin's node fields unvalidated.
+
+Keep `compileJSON` on the same side of the trust boundary as the serializer
+that produced the tree. To move a value across a boundary, send the JSON and
+call `fromJSON` on the receiving side, or send the output of `serialize` and
+evaluate it only where the sender is trusted.
+
 ## Push-based streaming serialization
 
 > [!NOTE]

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^26.2.0",
     "@vitest/ui": "^4.1.10",
     "esbuild": "^0.28.2",
-    "seroval": "1.6.1",
+    "seroval": "workspace:*",
     "tsdown": "^0.22.14",
     "tslib": "^2.8.1",
     "typescript": "^7.0.2",
@@ -46,6 +46,9 @@
     "access": "public"
   },
   "author": "Alexis Munsayac",
+  "types": "./dist/index.d.cts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "development": {
@@ -72,7 +75,7 @@
   "typesVersions": {
     "*": {
       "web": [
-        "./dist/types/web/index.d.ts"
+        "./dist/web.d.ts"
       ]
     }
   }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -6,7 +6,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "license": "MIT",
   "keywords": [

--- a/packages/seroval/package.json
+++ b/packages/seroval/package.json
@@ -62,9 +62,6 @@
     },
     "./package.json": "./package.json"
   },
-  "typesVersions": {
-    "*": {}
-  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js"
 }

--- a/packages/seroval/package.json
+++ b/packages/seroval/package.json
@@ -6,7 +6,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "license": "MIT",
   "keywords": [

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -246,8 +246,7 @@ function deserializeKnownValue<
   T extends Record<string, unknown>,
   K extends keyof T,
 >(node: SerovalNode, record: T, key: K): T[K] {
-  // biome-ignore lint/suspicious/noPrototypeBuiltins: `Object.hasOwn` needs Node 16.9 / Safari 15.4, newer than the runtimes the package targets.
-  if (Object.prototype.hasOwnProperty.call(record, key)) {
+  if (Object.hasOwn(record, key)) {
     return record[key];
   }
   throw new SerovalMalformedNodeError(node);

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -246,7 +246,8 @@ function deserializeKnownValue<
   T extends Record<string, unknown>,
   K extends keyof T,
 >(node: SerovalNode, record: T, key: K): T[K] {
-  if (Object.hasOwn(record, key)) {
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: `Object.hasOwn` needs Node 16.9 / Safari 15.4, newer than the runtimes the package targets.
+  if (Object.prototype.hasOwnProperty.call(record, key)) {
     return record[key];
   }
   throw new SerovalMalformedNodeError(node);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@<3.15.2: '>=3.15.2 <4'
+  js-yaml@>=4.0.0 <4.3.2: '>=4.3.2 <5'
+
 importers:
 
   .:
@@ -82,7 +86,7 @@ importers:
         specifier: ^0.28.2
         version: 0.28.2
       seroval:
-        specifier: 1.6.1
+        specifier: workspace:*
         version: link:../seroval
       tsdown:
         specifier: ^0.22.14
@@ -1277,12 +1281,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -2086,7 +2090,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -2838,12 +2842,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -3046,7 +3050,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
   - benchmark
 onlyBuiltDependencies:
   - esbuild
+overrides:
+  "js-yaml@<3.15.2": ">=3.15.2 <4"
+  "js-yaml@>=4.0.0 <4.3.2": ">=4.3.2 <5"


### PR DESCRIPTION
Housekeeping grouped into one PR. The `engines` change is the only item that affects consumers; the rest does not change runtime behaviour for a correct input.

- **Node.js floor.** `engines.node` moves from `>=10` to `>=20` in both packages. tsdown derives its syntax target from this field, so the build now reports `target: node20.0.0` and no longer downlevels `??` and `?.`. Node 10 through 18 are all end of life. Installs on those versions get an `EBADENGINE` warning under npm and a hard error under yarn or under pnpm with `engine-strict`, so the changeset is `minor`; bump it to `major` if you prefer to publish a floor change as a breaking release. Nothing in CI runs Node 20 (the job uses 22, and tsdown itself needs 22.18), so the floor is declared, not exercised. `deserializeKnownValue` keeps `Object.hasOwn`, which is available from Node 16.9.
- **`seroval` `package.json`.** Drops `typesVersions: { "*": {} }`, which maps nothing.
- **`seroval-plugins` `package.json`.** Adds `main`, `module` and `types` so the package resolves under `node10` module resolution like `seroval` does, and replaces the `typesVersions` entry that pointed at `dist/types/web/index.d.ts` (never emitted since the tsdown move) with `./dist/web.d.ts`, which is. The `seroval` dev dependency becomes `workspace:*`; the `1.6.1` pin only linked to the workspace because it happened to equal the workspace version, and a Dependabot bump (#172) would have switched the test suite to the npm copy.
- **Advisory.** `pnpm audit` reported js-yaml through `@changesets/cli` (GHSA for `maxTotalMergeKeys`). Two `overrides` in `pnpm-workspace.yaml` move it to 3.15.2 and 4.3.2 without crossing a major. `changeset status` still runs. The remaining two moderate findings are vitest 4.1.10, covered by #129 and #136.
- **Docs.** `docs/serialization.md` gains a "Trust boundary" section. `fromJSON` and `fromCrossJSON` validate their input; `compileJSON` and plugin `serialize` methods do not, and a tree from an untrusted source can place code in the emitted JavaScript through any string field. I confirmed this with a RegExp node whose flags were `g,alert(1)//` and a Number node whose `s` was a string. The section states which side of the boundary each function belongs on rather than adding validation, since validation would cost bundle bytes on a path that is only meant for trusted trees.

Related: #180 keeps an explicit `target: 'es2020'` in the tsdown configs so the syntax floor for browsers stays pinned independently of `engines`. #176 is closed as redundant, since the downleveling it worked around no longer happens.

Not included: dropping the duplicate `dist/dev/*.d.ts` files. That would cut 47 KB from the tarball but would break anyone resolving types through a `development` custom condition, and tarball size does not affect consumer bundles.

Tests: seroval 905 passing, seroval-plugins 178 passing against the workspace link, built with tsdown reporting `target: node20.0.0`.
