### PR TITLE
perf: share object classification between the parsers

### DIFF
--- a/.changeset/merge-duplicate-node-handlers.md
+++ b/.changeset/merge-duplicate-node-handlers.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Merge duplicated node creators, promise result and stream call handlers, and share one Temporal name table.

--- a/.changeset/shared-object-dispatch.md
+++ b/.changeset/shared-object-dispatch.md
@@ -1,0 +1,5 @@
+---
+'seroval': patch
+---
+
+Classify objects once in a shared `getObjectKind` helper so the sync, stream and async parsers no longer carry separate copies of the class checks and feature gates.

--- a/packages/seroval/src/core/base-primitives.ts
+++ b/packages/seroval/src/core/base-primitives.ts
@@ -199,33 +199,13 @@ export function createBoxedNode(
 }
 
 export function createTypedArrayNode(
+  type: SerovalNodeType.TypedArray | SerovalNodeType.BigIntTypedArray,
   id: number,
-  current: TypedArrayValue,
+  current: TypedArrayValue | BigIntTypedArrayValue,
   buffer: SerovalNode,
-): SerovalTypedArrayNode {
+): SerovalTypedArrayNode | SerovalBigIntTypedArrayNode {
   return createSerovalNode(
-    SerovalNodeType.TypedArray,
-    id,
-    NIL,
-    current.constructor.name,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    buffer,
-    current.byteOffset,
-    NIL,
-    current.length,
-  );
-}
-
-export function createBigIntTypedArrayNode(
-  id: number,
-  current: BigIntTypedArrayValue,
-  buffer: SerovalNode,
-): SerovalBigIntTypedArrayNode {
-  return createSerovalNode(
-    SerovalNodeType.BigIntTypedArray,
+    type,
     id,
     NIL,
     current.constructor.name,
@@ -262,27 +242,13 @@ export function createDataViewNode(
 }
 
 export function createErrorNode(
+  type: SerovalNodeType.Error | SerovalNodeType.AggregateError,
   id: number,
   current: Error,
   options: SerovalObjectRecordNode | undefined,
-): SerovalErrorNode {
+): SerovalErrorNode | SerovalAggregateErrorNode {
   return createSerovalNode(
-    SerovalNodeType.Error,
-    id,
-    getErrorConstructor(current),
-    NIL,
-    serializeString(current.message),
-    options,
-  );
-}
-
-export function createAggregateErrorNode(
-  id: number,
-  current: AggregateError,
-  options: SerovalObjectRecordNode | undefined,
-): SerovalAggregateErrorNode {
-  return createSerovalNode(
-    SerovalNodeType.AggregateError,
+    type,
     id,
     getErrorConstructor(current),
     NIL,
@@ -308,35 +274,18 @@ export function createSetNode(
 }
 
 export function createIteratorFactoryInstanceNode(
+  type:
+    | SerovalNodeType.IteratorFactoryInstance
+    | SerovalNodeType.AsyncIteratorFactoryInstance,
   factory: SerovalNodeWithID,
   items: SerovalNodeWithID,
-): SerovalIteratorFactoryInstanceNode {
-  return createSerovalNode(
-    SerovalNodeType.IteratorFactoryInstance,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    [factory, items],
-  );
-}
-
-export function createAsyncIteratorFactoryInstanceNode(
-  factory: SerovalNodeWithID,
-  items: SerovalNodeWithID,
-): SerovalAsyncIteratorFactoryInstanceNode {
-  return createSerovalNode(
-    SerovalNodeType.AsyncIteratorFactoryInstance,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    [factory, items],
-  );
+):
+  | SerovalIteratorFactoryInstanceNode
+  | SerovalAsyncIteratorFactoryInstanceNode {
+  return createSerovalNode(type, NIL, NIL, NIL, NIL, NIL, NIL, [
+    factory,
+    items,
+  ]);
 }
 
 export function createStreamConstructorNode(
@@ -357,55 +306,15 @@ export function createStreamConstructorNode(
   );
 }
 
-export function createStreamNextNode(
+export function createStreamNode(
+  type:
+    | SerovalNodeType.StreamNext
+    | SerovalNodeType.StreamThrow
+    | SerovalNodeType.StreamReturn,
   id: number,
   parsed: SerovalNode,
-): SerovalStreamNextNode {
-  return createSerovalNode(
-    SerovalNodeType.StreamNext,
-    id,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    parsed,
-  );
-}
-
-export function createStreamThrowNode(
-  id: number,
-  parsed: SerovalNode,
-): SerovalStreamThrowNode {
-  return createSerovalNode(
-    SerovalNodeType.StreamThrow,
-    id,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    parsed,
-  );
-}
-
-export function createStreamReturnNode(
-  id: number,
-  parsed: SerovalNode,
-): SerovalStreamReturnNode {
-  return createSerovalNode(
-    SerovalNodeType.StreamReturn,
-    id,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    NIL,
-    parsed,
-  );
+): SerovalStreamNextNode | SerovalStreamThrowNode | SerovalStreamReturnNode {
+  return createSerovalNode(type, id, NIL, NIL, NIL, NIL, NIL, NIL, parsed);
 }
 
 export function createSequenceNode(

--- a/packages/seroval/src/core/constants.ts
+++ b/packages/seroval/src/core/constants.ts
@@ -76,6 +76,17 @@ export const enum SerovalTemporalType {
   ZonedDateTime = 7,
 }
 
+export const TEMPORAL_TYPE_NAME: Record<SerovalTemporalType, string> = {
+  [SerovalTemporalType.Instant]: 'Instant',
+  [SerovalTemporalType.Duration]: 'Duration',
+  [SerovalTemporalType.PlainDate]: 'PlainDate',
+  [SerovalTemporalType.PlainDateTime]: 'PlainDateTime',
+  [SerovalTemporalType.PlainMonthDay]: 'PlainMonthDay',
+  [SerovalTemporalType.PlainTime]: 'PlainTime',
+  [SerovalTemporalType.PlainYearMonth]: 'PlainYearMonth',
+  [SerovalTemporalType.ZonedDateTime]: 'ZonedDateTime',
+};
+
 export const enum SerovalObjectFlags {
   None = 0,
   NonExtensible = 1,

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -17,7 +17,6 @@ import {
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
-import { Feature } from '../compat';
 import { NIL, SerovalNodeType } from '../constants';
 import {
   SerovalDepthLimitError,
@@ -77,9 +76,12 @@ import {
   createMapNode,
   createObjectNode,
   getArrayBufferView,
+  getObjectClass,
+  getObjectKind,
   getReferenceNode,
   getTemporalType,
   markParserRef,
+  ObjectKind,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
   parseSpecialReference,
@@ -455,15 +457,7 @@ export async function parseObjectAsync(
   if (isSequence(current)) {
     return parseSequence(ctx, depth, id, current);
   }
-  let currentClass: unknown = current.constructor;
-  // `constructor` is an ordinary own property, so data can shadow it
-  // (`JSON.parse('{"constructor":1}')`) and hide the real class. A class is
-  // always callable, so anything else means the lookup was shadowed — only
-  // then fall back to the prototype, keeping the common path free of it.
-  if (currentClass !== NIL && typeof currentClass !== 'function') {
-    const proto = Object.getPrototypeOf(current) as object | null;
-    currentClass = proto === null ? NIL : proto.constructor;
-  }
+  const currentClass = getObjectClass(current);
   if (currentClass === OpaqueReference) {
     return parseAsync(
       ctx,
@@ -475,16 +469,18 @@ export async function parseObjectAsync(
   if (parsed) {
     return parsed;
   }
-  switch (currentClass) {
-    case Object:
-      return parsePlainObject(
-        ctx,
-        depth,
-        id,
-        current as Record<string, unknown>,
-        false,
-      );
-    case NIL:
+  // Plain objects dominate real payloads; skip the classifier for them.
+  if (currentClass === Object) {
+    return parsePlainObject(
+      ctx,
+      depth,
+      id,
+      current as Record<string, unknown>,
+      false,
+    );
+  }
+  switch (getObjectKind(current, currentClass, ctx.base.features)) {
+    case ObjectKind.NullObject:
       return parsePlainObject(
         ctx,
         depth,
@@ -492,15 +488,9 @@ export async function parseObjectAsync(
         current as Record<string, unknown>,
         true,
       );
-    case Date:
+    case ObjectKind.Date:
       return createDateNode(id, current as unknown as Date);
-    case Error:
-    case EvalError:
-    case RangeError:
-    case ReferenceError:
-    case SyntaxError:
-    case TypeError:
-    case URIError:
+    case ObjectKind.Error:
       return parseError(
         ctx,
         depth,
@@ -508,26 +498,23 @@ export async function parseObjectAsync(
         id,
         current as unknown as Error,
       );
-    case Number:
-    case Boolean:
-    case String:
-    case BigInt:
+    case ObjectKind.AggregateError:
+      return parseError(
+        ctx,
+        depth,
+        SerovalNodeType.AggregateError,
+        id,
+        current as unknown as AggregateError,
+      );
+    case ObjectKind.Boxed:
       return parseBoxed(ctx, depth, id, current);
-    case ArrayBuffer:
+    case ObjectKind.ArrayBuffer:
       return createArrayBufferNode(
         ctx.base,
         id,
         current as unknown as ArrayBuffer,
       );
-    case Int8Array:
-    case Int16Array:
-    case Int32Array:
-    case Uint8Array:
-    case Uint16Array:
-    case Uint32Array:
-    case Uint8ClampedArray:
-    case Float32Array:
-    case Float64Array:
+    case ObjectKind.TypedArray:
       return parseTypedArray(
         ctx,
         depth,
@@ -535,78 +522,52 @@ export async function parseObjectAsync(
         id,
         current as unknown as TypedArrayValue,
       );
-    case DataView:
+    case ObjectKind.BigIntTypedArray:
+      return parseTypedArray(
+        ctx,
+        depth,
+        SerovalNodeType.BigIntTypedArray,
+        id,
+        current as unknown as BigIntTypedArrayValue,
+      );
+    case ObjectKind.DataView:
       return parseDataView(ctx, depth, id, current as unknown as DataView);
-    case Map:
+    case ObjectKind.Map:
       return parseMap(
         ctx,
         depth,
         id,
         current as unknown as Map<unknown, unknown>,
       );
-    case Set:
+    case ObjectKind.Set:
       return parseSet(ctx, depth, id, current as unknown as Set<unknown>);
-    default:
-      break;
-  }
-  // Promises
-  if (currentClass === Promise || current instanceof Promise) {
-    return parsePromise(ctx, depth, id, current as unknown as Promise<unknown>);
-  }
-  const currentFeatures = ctx.base.features;
-  if (currentFeatures & Feature.RegExp && currentClass === RegExp) {
-    return createRegExpNode(id, current as unknown as RegExp);
-  }
-  // BigInt Typed Arrays
-  if (currentFeatures & Feature.BigIntTypedArray) {
-    switch (currentClass) {
-      case BigInt64Array:
-      case BigUint64Array:
-        return parseTypedArray(
-          ctx,
-          depth,
-          SerovalNodeType.BigIntTypedArray,
-          id,
-          current as unknown as BigIntTypedArrayValue,
-        );
-      default:
-        break;
-    }
-  }
-  if (
-    currentFeatures & Feature.AggregateError &&
-    typeof AggregateError !== 'undefined' &&
-    (currentClass === AggregateError || current instanceof AggregateError)
-  ) {
-    return parseError(
-      ctx,
-      depth,
-      SerovalNodeType.AggregateError,
-      id,
-      current as unknown as AggregateError,
-    );
-  }
-  if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
-    const temporalType = getTemporalType(currentClass);
-    if (temporalType != null) {
+    case ObjectKind.Promise:
+      return parsePromise(
+        ctx,
+        depth,
+        id,
+        current as unknown as Promise<unknown>,
+      );
+    case ObjectKind.RegExp:
+      return createRegExpNode(id, current as unknown as RegExp);
+    case ObjectKind.Temporal:
       return createTemporalNode(
         id,
-        temporalType,
+        getTemporalType(currentClass) as SerovalTemporalType,
         current as unknown as Temporal.Instant,
       );
-    }
+    case ObjectKind.Iterable:
+      // Generator objects have no global constructor despite existing
+      return parsePlainObject(
+        ctx,
+        depth,
+        id,
+        current as Record<string, unknown>,
+        !!currentClass,
+      );
+    default:
+      throw new SerovalUnsupportedTypeError(current);
   }
-  // Slow path. We only need to handle Errors and Iterators
-  // since they have very broad implementations.
-  if (current instanceof Error) {
-    return parseError(ctx, depth, SerovalNodeType.Error, id, current);
-  }
-  // Generator functions don't have a global constructor
-  // despite existing
-  if (SYM_ITERATOR in current || SYM_ASYNC_ITERATOR in current) {
-    return parsePlainObject(ctx, depth, id, current, !!currentClass);
-  }
-  throw new SerovalUnsupportedTypeError(current);
 }
 
 export async function parseFunctionAsync(

--- a/packages/seroval/src/core/context/async-parser.ts
+++ b/packages/seroval/src/core/context/async-parser.ts
@@ -1,9 +1,6 @@
 import {
-  createAggregateErrorNode,
   createArrayNode,
-  createAsyncIteratorFactoryInstanceNode,
   createBigIntNode,
-  createBigIntTypedArrayNode,
   createBoxedNode,
   createDataViewNode,
   createDateNode,
@@ -15,15 +12,13 @@ import {
   createSequenceNode,
   createSetNode,
   createStreamConstructorNode,
-  createStreamNextNode,
-  createStreamReturnNode,
-  createStreamThrowNode,
+  createStreamNode,
   createStringNode,
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
 import { Feature } from '../compat';
-import { NIL, SerovalNodeType, SerovalTemporalType } from '../constants';
+import { NIL, SerovalNodeType } from '../constants';
 import {
   SerovalDepthLimitError,
   SerovalParserError,
@@ -83,6 +78,7 @@ import {
   createObjectNode,
   getArrayBufferView,
   getReferenceNode,
+  getTemporalType,
   markParserRef,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
@@ -166,6 +162,7 @@ async function parseProperties(
     keyNodes.push(parseWellKnownSymbol(ctx.base, SYM_ITERATOR));
     valueNodes.push(
       createIteratorFactoryInstanceNode(
+        SerovalNodeType.IteratorFactoryInstance,
         parseIteratorFactory(ctx.base),
         (await parseAsync(
           ctx,
@@ -180,7 +177,8 @@ async function parseProperties(
   if (SYM_ASYNC_ITERATOR in properties) {
     keyNodes.push(parseWellKnownSymbol(ctx.base, SYM_ASYNC_ITERATOR));
     valueNodes.push(
-      createAsyncIteratorFactoryInstanceNode(
+      createIteratorFactoryInstanceNode(
+        SerovalNodeType.AsyncIteratorFactoryInstance,
         parseAsyncIteratorFactory(ctx.base),
         (await parseAsync(
           ctx,
@@ -236,25 +234,13 @@ async function parseBoxed(
 async function parseTypedArray(
   ctx: AsyncParserContext,
   depth: number,
+  type: SerovalNodeType.TypedArray | SerovalNodeType.BigIntTypedArray,
   id: number,
-  current: TypedArrayValue,
-): Promise<SerovalTypedArrayNode> {
+  current: TypedArrayValue | BigIntTypedArrayValue,
+): Promise<SerovalTypedArrayNode | SerovalBigIntTypedArrayNode> {
   current = getArrayBufferView(ctx.base, current);
   return createTypedArrayNode(
-    id,
-    current,
-    await parseAsync(ctx, depth, current.buffer),
-  );
-}
-
-async function parseBigIntTypedArray(
-  ctx: AsyncParserContext,
-  depth: number,
-  id: number,
-  current: BigIntTypedArrayValue,
-): Promise<SerovalBigIntTypedArrayNode> {
-  current = getArrayBufferView(ctx.base, current);
-  return createBigIntTypedArrayNode(
+    type,
     id,
     current,
     await parseAsync(ctx, depth, current.buffer),
@@ -278,25 +264,13 @@ async function parseDataView(
 async function parseError(
   ctx: AsyncParserContext,
   depth: number,
+  type: SerovalNodeType.Error | SerovalNodeType.AggregateError,
   id: number,
   current: Error,
-): Promise<SerovalErrorNode> {
+): Promise<SerovalErrorNode | SerovalAggregateErrorNode> {
   const options = getErrorOptions(current, ctx.base.features);
   return createErrorNode(
-    id,
-    current,
-    options ? await parseProperties(ctx, depth, options) : NIL,
-  );
-}
-
-async function parseAggregateError(
-  ctx: AsyncParserContext,
-  depth: number,
-  id: number,
-  current: AggregateError,
-): Promise<SerovalAggregateErrorNode> {
-  const options = getErrorOptions(current, ctx.base.features);
-  return createAggregateErrorNode(
+    type,
     id,
     current,
     options ? await parseProperties(ctx, depth, options) : NIL,
@@ -395,7 +369,7 @@ function parseStreamHandle<T>(
       markParserRef(this.base, id);
       parseAsync(this, depth, value).then(
         data => {
-          sequence.push(createStreamNextNode(id, data));
+          sequence.push(createStreamNode(SerovalNodeType.StreamNext, id, data));
         },
         data => {
           reject(data);
@@ -407,7 +381,9 @@ function parseStreamHandle<T>(
       markParserRef(this.base, id);
       parseAsync(this, depth, value).then(
         data => {
-          sequence.push(createStreamThrowNode(id, data));
+          sequence.push(
+            createStreamNode(SerovalNodeType.StreamThrow, id, data),
+          );
           resolve(sequence);
           cleanup();
         },
@@ -421,7 +397,9 @@ function parseStreamHandle<T>(
       markParserRef(this.base, id);
       parseAsync(this, depth, value).then(
         data => {
-          sequence.push(createStreamReturnNode(id, data));
+          sequence.push(
+            createStreamNode(SerovalNodeType.StreamReturn, id, data),
+          );
           resolve(sequence);
           cleanup();
         },
@@ -523,7 +501,13 @@ export async function parseObjectAsync(
     case SyntaxError:
     case TypeError:
     case URIError:
-      return parseError(ctx, depth, id, current as unknown as Error);
+      return parseError(
+        ctx,
+        depth,
+        SerovalNodeType.Error,
+        id,
+        current as unknown as Error,
+      );
     case Number:
     case Boolean:
     case String:
@@ -547,6 +531,7 @@ export async function parseObjectAsync(
       return parseTypedArray(
         ctx,
         depth,
+        SerovalNodeType.TypedArray,
         id,
         current as unknown as TypedArrayValue,
       );
@@ -577,9 +562,10 @@ export async function parseObjectAsync(
     switch (currentClass) {
       case BigInt64Array:
       case BigUint64Array:
-        return parseBigIntTypedArray(
+        return parseTypedArray(
           ctx,
           depth,
+          SerovalNodeType.BigIntTypedArray,
           id,
           current as unknown as BigIntTypedArrayValue,
         );
@@ -592,71 +578,28 @@ export async function parseObjectAsync(
     typeof AggregateError !== 'undefined' &&
     (currentClass === AggregateError || current instanceof AggregateError)
   ) {
-    return parseAggregateError(
+    return parseError(
       ctx,
       depth,
+      SerovalNodeType.AggregateError,
       id,
       current as unknown as AggregateError,
     );
   }
   if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
-    switch (currentClass) {
-      case Temporal.Instant:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.Instant,
-          current as unknown as Temporal.Instant,
-        );
-      case Temporal.Duration:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.Duration,
-          current as unknown as Temporal.Duration,
-        );
-      case Temporal.PlainDate:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainDate,
-          current as unknown as Temporal.PlainDate,
-        );
-      case Temporal.PlainDateTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainDateTime,
-          current as unknown as Temporal.PlainDateTime,
-        );
-      case Temporal.PlainMonthDay:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainMonthDay,
-          current as unknown as Temporal.PlainMonthDay,
-        );
-      case Temporal.PlainTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainTime,
-          current as unknown as Temporal.PlainTime,
-        );
-      case Temporal.PlainYearMonth:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainYearMonth,
-          current as unknown as Temporal.PlainYearMonth,
-        );
-      case Temporal.ZonedDateTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.ZonedDateTime,
-          current as unknown as Temporal.ZonedDateTime,
-        );
-      default:
-        break;
+    const temporalType = getTemporalType(currentClass);
+    if (temporalType != null) {
+      return createTemporalNode(
+        id,
+        temporalType,
+        current as unknown as Temporal.Instant,
+      );
     }
   }
   // Slow path. We only need to handle Errors and Iterators
   // since they have very broad implementations.
   if (current instanceof Error) {
-    return parseError(ctx, depth, id, current);
+    return parseError(ctx, depth, SerovalNodeType.Error, id, current);
   }
   // Generator functions don't have a global constructor
   // despite existing

--- a/packages/seroval/src/core/context/deserializer.ts
+++ b/packages/seroval/src/core/context/deserializer.ts
@@ -5,8 +5,8 @@ import {
   NIL,
   SerovalNodeType,
   SerovalObjectFlags,
-  SerovalTemporalType,
   SYMBOL_REF,
+  TEMPORAL_TYPE_NAME,
 } from '../constants';
 import {
   ARRAY_BUFFER_CONSTRUCTOR,
@@ -25,7 +25,7 @@ import type { PluginAccessOptions } from '../plugin';
 import { SerovalMode } from '../plugin';
 import { getReference } from '../reference';
 import { createSequence, type Sequence, sequenceToIterator } from '../sequence';
-import type { Stream } from '../stream';
+import type { Stream, StreamListener } from '../stream';
 import { createStream, streamToAsyncIterable } from '../stream';
 import { deserializeString } from '../string';
 import type {
@@ -199,7 +199,7 @@ export class DeserializePluginContext {
 }
 
 function guardIndexedValue(ctx: BaseDeserializerContext, id: number): void {
-  if (id < 0 || !Number.isFinite(id) || !Number.isInteger(id)) {
+  if (id < 0 || !Number.isInteger(id)) {
     throw new SerovalMalformedNodeError({
       t: SerovalNodeType.IndexedValue,
       i: id,
@@ -399,36 +399,12 @@ function deserializeTemporal(
   if (!(ctx.base.features & Feature.Temporal)) {
     throw new SerovalUnsupportedNodeError(node);
   }
-  let value: unknown;
-  switch (node.c) {
-    case SerovalTemporalType.Instant:
-      value = Temporal.Instant.from(node.s);
-      break;
-    case SerovalTemporalType.Duration:
-      value = Temporal.Duration.from(node.s);
-      break;
-    case SerovalTemporalType.PlainDate:
-      value = Temporal.PlainDate.from(node.s);
-      break;
-    case SerovalTemporalType.PlainDateTime:
-      value = Temporal.PlainDateTime.from(node.s);
-      break;
-    case SerovalTemporalType.PlainMonthDay:
-      value = Temporal.PlainMonthDay.from(node.s);
-      break;
-    case SerovalTemporalType.PlainTime:
-      value = Temporal.PlainTime.from(node.s);
-      break;
-    case SerovalTemporalType.PlainYearMonth:
-      value = Temporal.PlainYearMonth.from(node.s);
-      break;
-    case SerovalTemporalType.ZonedDateTime:
-      value = Temporal.ZonedDateTime.from(node.s);
-      break;
-    default:
-      throw new SerovalMalformedNodeError(node);
-  }
-  return assignIndexedValue(ctx, node.i, value);
+  // `node.c` only ever indexes our own name table (own-property checked),
+  // so untrusted input cannot reach arbitrary `Temporal` members.
+  const construct = (
+    Temporal as unknown as Record<string, { from(value: string): unknown }>
+  )[deserializeKnownValue(node, TEMPORAL_TYPE_NAME, node.c)];
+  return assignIndexedValue(ctx, node.i, construct.from(node.s));
 }
 
 function deserializeRegExp(
@@ -651,33 +627,22 @@ function deserializePromiseConstructor(
   return value;
 }
 
-function deserializePromiseResolve(
+function deserializePromiseResult(
   ctx: DeserializerContext,
   depth: number,
-  node: SerovalPromiseResolveNode,
+  node: SerovalPromiseResolveNode | SerovalPromiseRejectNode,
 ): unknown {
   const deferred = ctx.base.refs.get(node.i) as
     | PromiseConstructorResolver
     | undefined;
   if (deferred) {
     validateNodeType(ctx, node, node.i, SerovalNodeType.PromiseConstructor);
-    deferred.s(deserialize(ctx, depth, node.a[1]));
-    return NIL;
-  }
-  throw new SerovalMissingInstanceError('Promise');
-}
-
-function deserializePromiseReject(
-  ctx: DeserializerContext,
-  depth: number,
-  node: SerovalPromiseRejectNode,
-): unknown {
-  const deferred = ctx.base.refs.get(node.i) as
-    | PromiseConstructorResolver
-    | undefined;
-  if (deferred) {
-    validateNodeType(ctx, node, node.i, SerovalNodeType.PromiseConstructor);
-    deferred.f(deserialize(ctx, depth, node.a[1]));
+    const value = deserialize(ctx, depth, node.a[1]);
+    if (node.t === SerovalNodeType.PromiseSuccess) {
+      deferred.s(value);
+    } else {
+      deferred.f(value);
+    }
     return NIL;
   }
   throw new SerovalMissingInstanceError('Promise');
@@ -720,43 +685,19 @@ function deserializeStreamConstructor(
   return result;
 }
 
-function deserializeStreamNext(
+function deserializeStreamCall(
   ctx: DeserializerContext,
   depth: number,
-  node: SerovalStreamNextNode,
+  node:
+    | SerovalStreamNextNode
+    | SerovalStreamThrowNode
+    | SerovalStreamReturnNode,
+  method: keyof StreamListener<unknown>,
 ): unknown {
   const deferred = ctx.base.refs.get(node.i) as Stream<unknown> | undefined;
   if (deferred) {
     validateNodeType(ctx, node, node.i, SerovalNodeType.StreamConstructor);
-    deferred.next(deserialize(ctx, depth, node.f));
-    return NIL;
-  }
-  throw new SerovalMissingInstanceError('Stream');
-}
-
-function deserializeStreamThrow(
-  ctx: DeserializerContext,
-  depth: number,
-  node: SerovalStreamThrowNode,
-): unknown {
-  const deferred = ctx.base.refs.get(node.i) as Stream<unknown> | undefined;
-  if (deferred) {
-    validateNodeType(ctx, node, node.i, SerovalNodeType.StreamConstructor);
-    deferred.throw(deserialize(ctx, depth, node.f));
-    return NIL;
-  }
-  throw new SerovalMissingInstanceError('Stream');
-}
-
-function deserializeStreamReturn(
-  ctx: DeserializerContext,
-  depth: number,
-  node: SerovalStreamReturnNode,
-): unknown {
-  const deferred = ctx.base.refs.get(node.i) as Stream<unknown> | undefined;
-  if (deferred) {
-    validateNodeType(ctx, node, node.i, SerovalNodeType.StreamConstructor);
-    deferred.return(deserialize(ctx, depth, node.f));
+    deferred[method](deserialize(ctx, depth, node.f));
     return NIL;
   }
   throw new SerovalMissingInstanceError('Stream');
@@ -856,9 +797,8 @@ function deserialize(
     case SerovalNodeType.PromiseConstructor:
       return deserializePromiseConstructor(ctx, node);
     case SerovalNodeType.PromiseSuccess:
-      return deserializePromiseResolve(ctx, depth, node);
     case SerovalNodeType.PromiseFailure:
-      return deserializePromiseReject(ctx, depth, node);
+      return deserializePromiseResult(ctx, depth, node);
     case SerovalNodeType.IteratorFactoryInstance:
       return deserializeIteratorFactoryInstance(ctx, depth, node);
     case SerovalNodeType.AsyncIteratorFactoryInstance:
@@ -866,11 +806,11 @@ function deserialize(
     case SerovalNodeType.StreamConstructor:
       return deserializeStreamConstructor(ctx, depth, node);
     case SerovalNodeType.StreamNext:
-      return deserializeStreamNext(ctx, depth, node);
+      return deserializeStreamCall(ctx, depth, node, 'next');
     case SerovalNodeType.StreamThrow:
-      return deserializeStreamThrow(ctx, depth, node);
+      return deserializeStreamCall(ctx, depth, node, 'throw');
     case SerovalNodeType.StreamReturn:
-      return deserializeStreamReturn(ctx, depth, node);
+      return deserializeStreamCall(ctx, depth, node, 'return');
     case SerovalNodeType.IteratorFactory:
       return deserializeIteratorFactory(ctx, depth, node);
     case SerovalNodeType.AsyncIteratorFactory:

--- a/packages/seroval/src/core/context/parser.ts
+++ b/packages/seroval/src/core/context/parser.ts
@@ -5,7 +5,12 @@ import {
 } from '../base-primitives';
 import { ALL_ENABLED } from '../compat';
 import type { WellKnownSymbols } from '../constants';
-import { INV_SYMBOL_REF, NIL, SerovalNodeType } from '../constants';
+import {
+  INV_SYMBOL_REF,
+  NIL,
+  SerovalNodeType,
+  SerovalTemporalType,
+} from '../constants';
 import { SerovalUnsupportedTypeError } from '../errors';
 import { createSerovalNode } from '../node';
 import type { PluginAccessOptions, SerovalMode } from '../plugin';
@@ -191,6 +196,31 @@ export function parseAsyncIteratorFactory(
       parseWellKnownSymbol(ctx, SYM_ASYNC_ITERATOR),
     ],
   );
+}
+
+export function getTemporalType(
+  currentClass: unknown,
+): SerovalTemporalType | undefined {
+  switch (currentClass) {
+    case Temporal.Instant:
+      return SerovalTemporalType.Instant;
+    case Temporal.Duration:
+      return SerovalTemporalType.Duration;
+    case Temporal.PlainDate:
+      return SerovalTemporalType.PlainDate;
+    case Temporal.PlainDateTime:
+      return SerovalTemporalType.PlainDateTime;
+    case Temporal.PlainMonthDay:
+      return SerovalTemporalType.PlainMonthDay;
+    case Temporal.PlainTime:
+      return SerovalTemporalType.PlainTime;
+    case Temporal.PlainYearMonth:
+      return SerovalTemporalType.PlainYearMonth;
+    case Temporal.ZonedDateTime:
+      return SerovalTemporalType.ZonedDateTime;
+    default:
+      return NIL;
+  }
 }
 
 export function createObjectNode(

--- a/packages/seroval/src/core/context/parser.ts
+++ b/packages/seroval/src/core/context/parser.ts
@@ -3,7 +3,7 @@ import {
   createReferenceNode,
   createWKSymbolNode,
 } from '../base-primitives';
-import { ALL_ENABLED } from '../compat';
+import { ALL_ENABLED, Feature } from '../compat';
 import type { WellKnownSymbols } from '../constants';
 import {
   INV_SYMBOL_REF,
@@ -221,6 +221,125 @@ export function getTemporalType(
     default:
       return NIL;
   }
+}
+
+export const enum ObjectKind {
+  Unsupported = 0,
+  PlainObject = 1,
+  NullObject = 2,
+  Date = 3,
+  Error = 4,
+  AggregateError = 5,
+  Boxed = 6,
+  ArrayBuffer = 7,
+  TypedArray = 8,
+  BigIntTypedArray = 9,
+  DataView = 10,
+  Map = 11,
+  Set = 12,
+  Promise = 13,
+  RegExp = 14,
+  Temporal = 15,
+  Iterable = 16,
+}
+
+export function getObjectClass(current: object): unknown {
+  const currentClass: unknown = current.constructor;
+  // `constructor` is an ordinary own property, so data can shadow it
+  // (`JSON.parse('{"constructor":1}')`) and hide the real class. A class is
+  // always callable, so anything else means the lookup was shadowed; only
+  // then fall back to the prototype, keeping the common path free of it.
+  if (currentClass !== NIL && typeof currentClass !== 'function') {
+    const proto = Object.getPrototypeOf(current) as object | null;
+    return proto === null ? NIL : proto.constructor;
+  }
+  return currentClass;
+}
+
+/**
+ * Decides how an object is parsed. Shared by the sync, stream and async
+ * parsers so the class checks and feature gates live in one place.
+ */
+export function getObjectKind(
+  current: object,
+  currentClass: unknown,
+  features: number,
+): ObjectKind {
+  switch (currentClass) {
+    case Object:
+      return ObjectKind.PlainObject;
+    case NIL:
+      return ObjectKind.NullObject;
+    case Date:
+      return ObjectKind.Date;
+    case Error:
+    case EvalError:
+    case RangeError:
+    case ReferenceError:
+    case SyntaxError:
+    case TypeError:
+    case URIError:
+      return ObjectKind.Error;
+    case Number:
+    case Boolean:
+    case String:
+    case BigInt:
+      return ObjectKind.Boxed;
+    case ArrayBuffer:
+      return ObjectKind.ArrayBuffer;
+    case Int8Array:
+    case Int16Array:
+    case Int32Array:
+    case Uint8Array:
+    case Uint16Array:
+    case Uint32Array:
+    case Uint8ClampedArray:
+    case Float32Array:
+    case Float64Array:
+      return ObjectKind.TypedArray;
+    case DataView:
+      return ObjectKind.DataView;
+    case Map:
+      return ObjectKind.Map;
+    case Set:
+      return ObjectKind.Set;
+    default:
+      break;
+  }
+  if (currentClass === Promise || current instanceof Promise) {
+    return ObjectKind.Promise;
+  }
+  if (features & Feature.RegExp && currentClass === RegExp) {
+    return ObjectKind.RegExp;
+  }
+  if (
+    features & Feature.BigIntTypedArray &&
+    (currentClass === BigInt64Array || currentClass === BigUint64Array)
+  ) {
+    return ObjectKind.BigIntTypedArray;
+  }
+  if (
+    features & Feature.AggregateError &&
+    typeof AggregateError !== 'undefined' &&
+    (currentClass === AggregateError || current instanceof AggregateError)
+  ) {
+    return ObjectKind.AggregateError;
+  }
+  if (
+    features & Feature.Temporal &&
+    typeof Temporal !== 'undefined' &&
+    getTemporalType(currentClass) != null
+  ) {
+    return ObjectKind.Temporal;
+  }
+  // Slow path. Errors and iterables have very broad implementations.
+  if (current instanceof Error) {
+    return ObjectKind.Error;
+  }
+  if (SYM_ITERATOR in current || SYM_ASYNC_ITERATOR in current) {
+    return ObjectKind.Iterable;
+  }
+  return ObjectKind.Unsupported;
 }
 
 export function createObjectNode(

--- a/packages/seroval/src/core/context/serializer.ts
+++ b/packages/seroval/src/core/context/serializer.ts
@@ -5,8 +5,8 @@ import {
   NIL,
   SerovalNodeType,
   SerovalObjectFlags,
-  SerovalTemporalType,
   SYMBOL_STRING,
+  TEMPORAL_TYPE_NAME,
 } from '../constants';
 import {
   SERIALIZED_ASYNC_ITERATOR_CONSTRUCTOR,
@@ -853,23 +853,12 @@ function serializeDate(node: SerovalDateNode): string {
   return 'new Date("' + node.s + '")';
 }
 
-const TEMPORAL_CONSTRUCTOR: Record<SerovalTemporalType, string> = {
-  [SerovalTemporalType.Instant]: 'Temporal.Instant',
-  [SerovalTemporalType.Duration]: 'Temporal.Duration',
-  [SerovalTemporalType.PlainDate]: 'Temporal.PlainDate',
-  [SerovalTemporalType.PlainDateTime]: 'Temporal.PlainDateTime',
-  [SerovalTemporalType.PlainMonthDay]: 'Temporal.PlainMonthDay',
-  [SerovalTemporalType.PlainTime]: 'Temporal.PlainTime',
-  [SerovalTemporalType.PlainYearMonth]: 'Temporal.PlainYearMonth',
-  [SerovalTemporalType.ZonedDateTime]: 'Temporal.ZonedDateTime',
-};
-
 function serializeTemporal(
   ctx: SerializerContext,
   node: SerovalTemporalNode,
 ): string {
   if (ctx.base.features & Feature.Temporal) {
-    return TEMPORAL_CONSTRUCTOR[node.c] + '.from("' + node.s + '")';
+    return 'Temporal.' + TEMPORAL_TYPE_NAME[node.c] + '.from("' + node.s + '")';
   }
   throw new SerovalUnsupportedNodeError(node);
 }
@@ -1151,26 +1140,9 @@ function serializePromiseConstructor(
   return '(' + resolver + ').p';
 }
 
-function serializePromiseResolve(
+function serializePromiseResult(
   ctx: SerializerContext,
-  node: SerovalPromiseResolveNode,
-): string {
-  if (ctx.mode === SerovalMode.Vanilla) {
-    throw new SerovalUnsupportedNodeError(node);
-  }
-  return (
-    getConstructor(ctx, node.a[0]) +
-    '(' +
-    getRefParam(ctx, node.i) +
-    ',' +
-    serialize(ctx, node.a[1]) +
-    ')'
-  );
-}
-
-function serializePromiseReject(
-  ctx: SerializerContext,
-  node: SerovalPromiseRejectNode,
+  node: SerovalPromiseResolveNode | SerovalPromiseRejectNode,
 ): string {
   if (ctx.mode === SerovalMode.Vanilla) {
     throw new SerovalUnsupportedNodeError(node);
@@ -1234,7 +1206,9 @@ function serializeIteratorFactory(
 
 function serializeIteratorFactoryInstance(
   ctx: SerializerContext,
-  node: SerovalIteratorFactoryInstanceNode,
+  node:
+    | SerovalIteratorFactoryInstanceNode
+    | SerovalAsyncIteratorFactoryInstanceNode,
 ): string {
   return getConstructor(ctx, node.a[0]) + '(' + serialize(ctx, node.a[1]) + ')';
 }
@@ -1280,13 +1254,6 @@ function serializeAsyncIteratorFactory(
   return iterator;
 }
 
-function serializeAsyncIteratorFactoryInstance(
-  ctx: SerializerContext,
-  node: SerovalAsyncIteratorFactoryInstanceNode,
-): string {
-  return getConstructor(ctx, node.a[0]) + '(' + serialize(ctx, node.a[1]) + ')';
-}
-
 function serializeStreamConstructor(
   ctx: SerializerContext,
   node: SerovalStreamConstructorNode,
@@ -1307,25 +1274,17 @@ function serializeStreamConstructor(
   return result;
 }
 
-function serializeStreamNext(
+function serializeStreamCall(
   ctx: SerializerContext,
-  node: SerovalStreamNextNode,
+  node:
+    | SerovalStreamNextNode
+    | SerovalStreamThrowNode
+    | SerovalStreamReturnNode,
+  method: string,
 ): string {
-  return getRefParam(ctx, node.i) + '.next(' + serialize(ctx, node.f) + ')';
-}
-
-function serializeStreamThrow(
-  ctx: SerializerContext,
-  node: SerovalStreamThrowNode,
-): string {
-  return getRefParam(ctx, node.i) + '.throw(' + serialize(ctx, node.f) + ')';
-}
-
-function serializeStreamReturn(
-  ctx: SerializerContext,
-  node: SerovalStreamReturnNode,
-): string {
-  return getRefParam(ctx, node.i) + '.return(' + serialize(ctx, node.f) + ')';
+  return (
+    getRefParam(ctx, node.i) + '.' + method + '(' + serialize(ctx, node.f) + ')'
+  );
 }
 
 function serializeSequenceItem(
@@ -1444,25 +1403,23 @@ function serialize(ctx: SerializerContext, node: SerovalNode): string {
     case SerovalNodeType.IndexedValue:
       return getRefParam(ctx, node.i);
     case SerovalNodeType.PromiseSuccess:
-      return serializePromiseResolve(ctx, node);
     case SerovalNodeType.PromiseFailure:
-      return serializePromiseReject(ctx, node);
+      return serializePromiseResult(ctx, node);
     case SerovalNodeType.IteratorFactory:
       return serializeIteratorFactory(ctx, node);
     case SerovalNodeType.IteratorFactoryInstance:
+    case SerovalNodeType.AsyncIteratorFactoryInstance:
       return serializeIteratorFactoryInstance(ctx, node);
     case SerovalNodeType.AsyncIteratorFactory:
       return serializeAsyncIteratorFactory(ctx, node);
-    case SerovalNodeType.AsyncIteratorFactoryInstance:
-      return serializeAsyncIteratorFactoryInstance(ctx, node);
     case SerovalNodeType.StreamConstructor:
       return serializeStreamConstructor(ctx, node);
     case SerovalNodeType.StreamNext:
-      return serializeStreamNext(ctx, node);
+      return serializeStreamCall(ctx, node, 'next');
     case SerovalNodeType.StreamThrow:
-      return serializeStreamThrow(ctx, node);
+      return serializeStreamCall(ctx, node, 'throw');
     case SerovalNodeType.StreamReturn:
-      return serializeStreamReturn(ctx, node);
+      return serializeStreamCall(ctx, node, 'return');
     default:
       return assignIndexedValue(ctx, node.i, serializeAssignable(ctx, node));
   }

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -17,7 +17,6 @@ import {
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
-import { Feature } from '../compat';
 import { NIL, SerovalNodeType } from '../constants';
 import {
   SerovalDepthLimitError,
@@ -81,8 +80,11 @@ import {
   createObjectNode,
   createPromiseConstructorNode,
   getArrayBufferView,
+  getObjectClass,
+  getObjectKind,
   getReferenceNode,
   getTemporalType,
+  ObjectKind,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
   parseSpecialReference,
@@ -615,16 +617,18 @@ function parseObjectPhase2(
   current: object,
   currentClass: unknown,
 ): SerovalNode {
-  switch (currentClass) {
-    case Object:
-      return parsePlainObject(
-        ctx,
-        depth,
-        id,
-        current as Record<string, unknown>,
-        false,
-      );
-    case NIL:
+  // Plain objects dominate real payloads; skip the classifier for them.
+  if (currentClass === Object) {
+    return parsePlainObject(
+      ctx,
+      depth,
+      id,
+      current as Record<string, unknown>,
+      false,
+    );
+  }
+  switch (getObjectKind(current, currentClass, ctx.base.features)) {
+    case ObjectKind.NullObject:
       return parsePlainObject(
         ctx,
         depth,
@@ -632,15 +636,9 @@ function parseObjectPhase2(
         current as Record<string, unknown>,
         true,
       );
-    case Date:
+    case ObjectKind.Date:
       return createDateNode(id, current as unknown as Date);
-    case Error:
-    case EvalError:
-    case RangeError:
-    case ReferenceError:
-    case SyntaxError:
-    case TypeError:
-    case URIError:
+    case ObjectKind.Error:
       return parseError(
         ctx,
         depth,
@@ -648,26 +646,23 @@ function parseObjectPhase2(
         id,
         current as unknown as Error,
       );
-    case Number:
-    case Boolean:
-    case String:
-    case BigInt:
+    case ObjectKind.AggregateError:
+      return parseError(
+        ctx,
+        depth,
+        SerovalNodeType.AggregateError,
+        id,
+        current as unknown as AggregateError,
+      );
+    case ObjectKind.Boxed:
       return parseBoxed(ctx, depth, id, current);
-    case ArrayBuffer:
+    case ObjectKind.ArrayBuffer:
       return createArrayBufferNode(
         ctx.base,
         id,
         current as unknown as ArrayBuffer,
       );
-    case Int8Array:
-    case Int16Array:
-    case Int32Array:
-    case Uint8Array:
-    case Uint16Array:
-    case Uint32Array:
-    case Uint8ClampedArray:
-    case Float32Array:
-    case Float64Array:
+    case ObjectKind.TypedArray:
       return parseTypedArray(
         ctx,
         depth,
@@ -675,78 +670,52 @@ function parseObjectPhase2(
         id,
         current as unknown as TypedArrayValue,
       );
-    case DataView:
+    case ObjectKind.BigIntTypedArray:
+      return parseTypedArray(
+        ctx,
+        depth,
+        SerovalNodeType.BigIntTypedArray,
+        id,
+        current as unknown as BigIntTypedArrayValue,
+      );
+    case ObjectKind.DataView:
       return parseDataView(ctx, depth, id, current as unknown as DataView);
-    case Map:
+    case ObjectKind.Map:
       return parseMap(
         ctx,
         depth,
         id,
         current as unknown as Map<unknown, unknown>,
       );
-    case Set:
+    case ObjectKind.Set:
       return parseSet(ctx, depth, id, current as unknown as Set<unknown>);
-    default:
-      break;
-  }
-  // Promises
-  if (currentClass === Promise || current instanceof Promise) {
-    return parsePromise(ctx, depth, id, current as unknown as Promise<unknown>);
-  }
-  const currentFeatures = ctx.base.features;
-  if (currentFeatures & Feature.RegExp && currentClass === RegExp) {
-    return createRegExpNode(id, current as unknown as RegExp);
-  }
-  // BigInt Typed Arrays
-  if (currentFeatures & Feature.BigIntTypedArray) {
-    switch (currentClass) {
-      case BigInt64Array:
-      case BigUint64Array:
-        return parseTypedArray(
-          ctx,
-          depth,
-          SerovalNodeType.BigIntTypedArray,
-          id,
-          current as unknown as BigIntTypedArrayValue,
-        );
-      default:
-        break;
-    }
-  }
-  if (
-    currentFeatures & Feature.AggregateError &&
-    typeof AggregateError !== 'undefined' &&
-    (currentClass === AggregateError || current instanceof AggregateError)
-  ) {
-    return parseError(
-      ctx,
-      depth,
-      SerovalNodeType.AggregateError,
-      id,
-      current as unknown as AggregateError,
-    );
-  }
-  if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
-    const temporalType = getTemporalType(currentClass);
-    if (temporalType != null) {
+    case ObjectKind.Promise:
+      return parsePromise(
+        ctx,
+        depth,
+        id,
+        current as unknown as Promise<unknown>,
+      );
+    case ObjectKind.RegExp:
+      return createRegExpNode(id, current as unknown as RegExp);
+    case ObjectKind.Temporal:
       return createTemporalNode(
         id,
-        temporalType,
+        getTemporalType(currentClass) as SerovalTemporalType,
         current as unknown as Temporal.Instant,
       );
-    }
+    case ObjectKind.Iterable:
+      // Generator objects have no global constructor despite existing
+      return parsePlainObject(
+        ctx,
+        depth,
+        id,
+        current as Record<string, unknown>,
+        !!currentClass,
+      );
+    default:
+      throw new SerovalUnsupportedTypeError(current);
   }
-  // Slow path. We only need to handle Errors and Iterators
-  // since they have very broad implementations.
-  if (current instanceof Error) {
-    return parseError(ctx, depth, SerovalNodeType.Error, id, current);
-  }
-  // Generator functions don't have a global constructor
-  // despite existing
-  if (SYM_ITERATOR in current || SYM_ASYNC_ITERATOR in current) {
-    return parsePlainObject(ctx, depth, id, current, !!currentClass);
-  }
-  throw new SerovalUnsupportedTypeError(current);
 }
 
 function parseObject(
@@ -764,15 +733,7 @@ function parseObject(
   if (isSequence(current)) {
     return parseSequence(ctx, depth, id, current);
   }
-  let currentClass: unknown = current.constructor;
-  // `constructor` is an ordinary own property, so data can shadow it
-  // (`JSON.parse('{"constructor":1}')`) and hide the real class. A class is
-  // always callable, so anything else means the lookup was shadowed — only
-  // then fall back to the prototype, keeping the common path free of it.
-  if (currentClass !== NIL && typeof currentClass !== 'function') {
-    const proto = Object.getPrototypeOf(current) as object | null;
-    currentClass = proto === null ? NIL : proto.constructor;
-  }
+  const currentClass = getObjectClass(current);
   if (currentClass === OpaqueReference) {
     return parseSOS(
       ctx,

--- a/packages/seroval/src/core/context/sync-parser.ts
+++ b/packages/seroval/src/core/context/sync-parser.ts
@@ -1,9 +1,6 @@
 import {
-  createAggregateErrorNode,
   createArrayNode,
-  createAsyncIteratorFactoryInstanceNode,
   createBigIntNode,
-  createBigIntTypedArrayNode,
   createBoxedNode,
   createDataViewNode,
   createDateNode,
@@ -15,15 +12,13 @@ import {
   createSequenceNode,
   createSetNode,
   createStreamConstructorNode,
-  createStreamNextNode,
-  createStreamReturnNode,
-  createStreamThrowNode,
+  createStreamNode,
   createStringNode,
   createTemporalNode,
   createTypedArrayNode,
 } from '../base-primitives';
 import { Feature } from '../compat';
-import { NIL, SerovalNodeType, SerovalTemporalType } from '../constants';
+import { NIL, SerovalNodeType } from '../constants';
 import {
   SerovalDepthLimitError,
   SerovalParserError,
@@ -87,6 +82,7 @@ import {
   createPromiseConstructorNode,
   getArrayBufferView,
   getReferenceNode,
+  getTemporalType,
   parseAsyncIteratorFactory,
   parseIteratorFactory,
   parseSpecialReference,
@@ -266,6 +262,7 @@ function parseProperties(
     keyNodes.push(parseWellKnownSymbol(ctx.base, SYM_ITERATOR));
     valueNodes.push(
       createIteratorFactoryInstanceNode(
+        SerovalNodeType.IteratorFactoryInstance,
         parseIteratorFactory(ctx.base),
         parseSOS(
           ctx,
@@ -280,7 +277,8 @@ function parseProperties(
   if (SYM_ASYNC_ITERATOR in properties) {
     keyNodes.push(parseWellKnownSymbol(ctx.base, SYM_ASYNC_ITERATOR));
     valueNodes.push(
-      createAsyncIteratorFactoryInstanceNode(
+      createIteratorFactoryInstanceNode(
+        SerovalNodeType.AsyncIteratorFactoryInstance,
         parseAsyncIteratorFactory(ctx.base),
         parseSOS(
           ctx,
@@ -338,25 +336,13 @@ function parseBoxed(
 function parseTypedArray(
   ctx: SOSParserContext,
   depth: number,
+  type: SerovalNodeType.TypedArray | SerovalNodeType.BigIntTypedArray,
   id: number,
-  current: TypedArrayValue,
-): SerovalTypedArrayNode {
+  current: TypedArrayValue | BigIntTypedArrayValue,
+): SerovalTypedArrayNode | SerovalBigIntTypedArrayNode {
   current = getArrayBufferView(ctx.base, current);
   return createTypedArrayNode(
-    id,
-    current,
-    parseSOS(ctx, depth, current.buffer),
-  );
-}
-
-function parseBigIntTypedArray(
-  ctx: SOSParserContext,
-  depth: number,
-  id: number,
-  current: BigIntTypedArrayValue,
-): SerovalBigIntTypedArrayNode {
-  current = getArrayBufferView(ctx.base, current);
-  return createBigIntTypedArrayNode(
+    type,
     id,
     current,
     parseSOS(ctx, depth, current.buffer),
@@ -376,25 +362,13 @@ function parseDataView(
 function parseError(
   ctx: SOSParserContext,
   depth: number,
+  type: SerovalNodeType.Error | SerovalNodeType.AggregateError,
   id: number,
   current: Error,
-): SerovalErrorNode {
+): SerovalErrorNode | SerovalAggregateErrorNode {
   const options = getErrorOptions(current, ctx.base.features);
   return createErrorNode(
-    id,
-    current,
-    options ? parseProperties(ctx, depth, options) : NIL,
-  );
-}
-
-function parseAggregateError(
-  ctx: SOSParserContext,
-  depth: number,
-  id: number,
-  current: AggregateError,
-): SerovalAggregateErrorNode {
-  const options = getErrorOptions(current, ctx.base.features);
-  return createAggregateErrorNode(
+    type,
     id,
     current,
     options ? parseProperties(ctx, depth, options) : NIL,
@@ -449,7 +423,10 @@ function parseStream(
       if (ctx.state.alive) {
         const parsed = parseWithError(ctx, depth, value);
         if (parsed) {
-          onParse(ctx, createStreamNextNode(id, parsed));
+          onParse(
+            ctx,
+            createStreamNode(SerovalNodeType.StreamNext, id, parsed),
+          );
         }
       }
     },
@@ -457,7 +434,10 @@ function parseStream(
       if (ctx.state.alive) {
         const parsed = parseWithError(ctx, depth, value);
         if (parsed) {
-          onParse(ctx, createStreamThrowNode(id, parsed));
+          onParse(
+            ctx,
+            createStreamNode(SerovalNodeType.StreamThrow, id, parsed),
+          );
         }
       }
       popPendingState(ctx);
@@ -466,7 +446,10 @@ function parseStream(
       if (ctx.state.alive) {
         const parsed = parseWithError(ctx, depth, value);
         if (parsed) {
-          onParse(ctx, createStreamReturnNode(id, parsed));
+          onParse(
+            ctx,
+            createStreamNode(SerovalNodeType.StreamReturn, id, parsed),
+          );
         }
       }
       popPendingState(ctx);
@@ -658,7 +641,13 @@ function parseObjectPhase2(
     case SyntaxError:
     case TypeError:
     case URIError:
-      return parseError(ctx, depth, id, current as unknown as Error);
+      return parseError(
+        ctx,
+        depth,
+        SerovalNodeType.Error,
+        id,
+        current as unknown as Error,
+      );
     case Number:
     case Boolean:
     case String:
@@ -682,6 +671,7 @@ function parseObjectPhase2(
       return parseTypedArray(
         ctx,
         depth,
+        SerovalNodeType.TypedArray,
         id,
         current as unknown as TypedArrayValue,
       );
@@ -712,9 +702,10 @@ function parseObjectPhase2(
     switch (currentClass) {
       case BigInt64Array:
       case BigUint64Array:
-        return parseBigIntTypedArray(
+        return parseTypedArray(
           ctx,
           depth,
+          SerovalNodeType.BigIntTypedArray,
           id,
           current as unknown as BigIntTypedArrayValue,
         );
@@ -727,71 +718,28 @@ function parseObjectPhase2(
     typeof AggregateError !== 'undefined' &&
     (currentClass === AggregateError || current instanceof AggregateError)
   ) {
-    return parseAggregateError(
+    return parseError(
       ctx,
       depth,
+      SerovalNodeType.AggregateError,
       id,
       current as unknown as AggregateError,
     );
   }
   if (currentFeatures & Feature.Temporal && typeof Temporal !== 'undefined') {
-    switch (currentClass) {
-      case Temporal.Instant:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.Instant,
-          current as unknown as Temporal.Instant,
-        );
-      case Temporal.Duration:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.Duration,
-          current as unknown as Temporal.Duration,
-        );
-      case Temporal.PlainDate:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainDate,
-          current as unknown as Temporal.PlainDate,
-        );
-      case Temporal.PlainDateTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainDateTime,
-          current as unknown as Temporal.PlainDateTime,
-        );
-      case Temporal.PlainMonthDay:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainMonthDay,
-          current as unknown as Temporal.PlainMonthDay,
-        );
-      case Temporal.PlainTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainTime,
-          current as unknown as Temporal.PlainTime,
-        );
-      case Temporal.PlainYearMonth:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.PlainYearMonth,
-          current as unknown as Temporal.PlainYearMonth,
-        );
-      case Temporal.ZonedDateTime:
-        return createTemporalNode(
-          id,
-          SerovalTemporalType.ZonedDateTime,
-          current as unknown as Temporal.ZonedDateTime,
-        );
-      default:
-        break;
+    const temporalType = getTemporalType(currentClass);
+    if (temporalType != null) {
+      return createTemporalNode(
+        id,
+        temporalType,
+        current as unknown as Temporal.Instant,
+      );
     }
   }
   // Slow path. We only need to handle Errors and Iterators
   // since they have very broad implementations.
   if (current instanceof Error) {
-    return parseError(ctx, depth, id, current);
+    return parseError(ctx, depth, SerovalNodeType.Error, id, current);
   }
   // Generator functions don't have a global constructor
   // despite existing


### PR DESCRIPTION
> Stacked on #178. The first commit here is #178's; review only the second (`perf: share object classification between the parsers`). Once #178 lands this rebases to a single commit.

After #178 the sync/stream parser and the async parser still each carried a full copy of the object dispatch: the constructor-shadow check, the `switch` over built-in classes, and the feature-gated checks for `Promise`, `RegExp`, BigInt typed arrays, `AggregateError`, Temporal, `Error` subclasses and iterables. Roughly 130 lines twice, and any new class had to be added in both places.

`parser.ts` now exposes `getObjectClass` (the shadow-safe constructor lookup) and `getObjectKind`, which returns an `ObjectKind` const enum. Both parsers switch over that enum and call their own sync or async handlers. Plain objects, which dominate real payloads, take a direct `currentClass === Object` path ahead of the classifier so the common case does not pay the extra call.

Behaviour is unchanged: the classifier checks the same conditions in the same order, so every class resolves to the same handler it did before, and all 905 tests and snapshots pass.

Measured as minified browser ESM consumer bundles (ES2020) with esbuild 0.28.2, gzip level 9, compared with #178's head `545a4cb`:

| Import | minified | gzip |
| --- | ---: | ---: |
| Full export set | 45,646 -> 42,012 B | 12,525 -> 12,338 B |
| `serialize` | 26,956 -> 25,192 B | 8,538 -> 8,495 B |
| `deserialize` | 976 -> 976 B | 485 -> 485 B |
| Client set¹ | 12,361 -> 11,763 B | 4,328 -> 4,298 B |
| Server set² | 33,972 -> 31,054 B | 9,696 -> 9,619 B |

¹ `fromCrossJSON`, `fromJSON`, `createStream`, `createReference`, `getCrossReferenceHeader`. ² `toCrossJSONStream`, `toCrossJSONAsync`, `toJSONAsync`, `crossSerializeStream`, `Serializer`, `createReference`, `createStream`.

Timings on Node 24.14.1 for `serialize` over 10k nested records, 20k unique keys, 900-deep arrays and 5k objects sharing a cyclic parent are within ±5% of #178 across three alternating runs, which is inside run-to-run noise on this machine.

Conflicts with #182 (`parseProperties`) are limited to import lists.
